### PR TITLE
Replaces ${CMAKE_SOURCE_DIR} by ${PROJECT_SOURCE_DIR}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,14 +26,20 @@ else()
 endif()
 
 find_package(PkgConfig)
-pkg_check_modules(LIBFM REQUIRED
+pkg_check_modules(SYSTEM_LIBS REQUIRED
   glib-2.0
   gio-2.0
   gio-unix-2.0
-  libfm>=1.2.0
-  libmenu-cache>=0.4.0
   ${XLIB} # we need to make this optional when trying to support Wayland
 #  libstartup-notification-1.0
+)
+
+pkg_check_modules(LIBFM REQUIRED
+  libfm>=1.2.0
+)
+
+pkg_check_modules(LIBMENUCACHE REQUIRED
+  libmenu-cache>=0.4.0
 )
 
 include(GNUInstallDirs)

--- a/libfm-qt/CMakeLists.txt
+++ b/libfm-qt/CMakeLists.txt
@@ -1,13 +1,17 @@
 include_directories(
   ${QT_INCLUDES}
   ${LIBFM_INCLUDE_DIRS}
-  ${LIBFM_libfm_INCLUDEDIR}/libfm # to workaround incorrect #include in fm-actions.
+  ${LIBFM_INCLUDEDIR}/libfm # to workaround incorrect #include in fm-actions.
+  ${LIBMENUCACHE_INCLUDE_DIRS}
+  ${SYSTEM_LIBS_INCLUDE_DIRS}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 link_directories(
   ${LIBFM_LIBRARY_DIRS}
+  ${LIBMENUCACHE_LIBRARY_DIRS}
+  ${SYSTEM_LIBS_LIBRARY_DIRS}
 )
 
 set(libfm_SRCS
@@ -83,7 +87,7 @@ set_property(
 )
 
 # only turn on custom actions support if it is enabled in libfm.
-if(EXISTS ${LIBFM_libfm_INCLUDEDIR}/libfm/fm-actions.h )
+if(EXISTS ${LIBFM_INCLUDEDIR}/libfm/fm-actions.h )
   set_property(TARGET fm-qt APPEND PROPERTY COMPILE_DEFINITIONS CUSTOM_ACTIONS)
 endif()
 
@@ -91,6 +95,8 @@ target_link_libraries(fm-qt
   ${QT_QTCORE_LIBRARY}
   ${QT_QTGUI_LIBRARY}
   ${LIBFM_LIBRARIES}
+  ${LIBMENUCACHE_LIBRARIES}
+  ${SYSTEM_LIBS_LIBRARIES}
 )
 
 # set libtool soname

--- a/pcmanfm/CMakeLists.txt
+++ b/pcmanfm/CMakeLists.txt
@@ -1,6 +1,8 @@
 include_directories(
   ${QT_INCLUDES}
   ${LIBFM_INCLUDE_DIRS}
+  ${LIBMENUCACHE_INCLUDE_DIRS}
+  ${SYSTEM_LIBS_INCLUDE_DIRS}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${PROJECT_SOURCE_DIR}/libfm-qt
@@ -8,6 +10,8 @@ include_directories(
 
 link_directories(
   ${LIBFM_LIBRARY_DIRS}
+  ${LIBMENUCACHE_LIBRARY_DIRS}
+  ${SYSTEM_LIBS_LIBRARY_DIRS}
 )
 
 set(pcmanfm_SRCS
@@ -66,13 +70,15 @@ set_property(
    PROPERTY COMPILE_DEFINITIONS
    LIBFM_QT_API=Q_DECL_IMPORT
    PCMANFM_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/pcmanfm-qt"
-   LIBFM_DATA_DIR="${LIBFM_libfm_PREFIX}/share/libfm" # This is a little bit dirty
+   LIBFM_DATA_DIR="${LIBFM_PREFIX}/share/libfm" # This is a little bit dirty
 )
 target_link_libraries(pcmanfm-qt 
   ${QT_QTCORE_LIBRARY}
   ${QT_QTGUI_LIBRARY}
   ${QT_QTDBUS_LIBRARY}
   ${LIBFM_LIBRARIES}
+  ${LIBMENUCACHE_LIBRARIES}
+  ${SYSTEM_LIBS_LIBRARIES}
   fm-qt
 )
 


### PR DESCRIPTION
When using a top level CMakeLists.txt ${CMAKE_SOURCE_DIR} will contain
the directory containing the top level CMakeLists.txt and....
${CMAKE_SOURCE_DIR}/libfm-qt will be an non existing directory. It breaks
the build.

${PROJECT_SOURCE_DIR} contains the full path to the root of the project
source directory, i.e. to the nearest directory where CMakeLists.txt
contains the PROJECT() command. That's precisely what we want!

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
