### PR TITLE
Makes the "Show Hidden" option be saved in settings file and properly loaded

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -285,6 +285,7 @@ void MainWindow::on_actionFolderProperties_triggered() {
 void MainWindow::on_actionShowHidden_triggered(bool checked) {
   TabPage* tabPage = currentPage();
   tabPage->setShowHidden(checked);
+  static_cast<Application*>(qApp)->settings().setShowHidden(checked);
 }
 
 void MainWindow::on_actionByFileName_triggered(bool checked) {

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -46,7 +46,7 @@ TabPage::TabPage(FmPath* path, QWidget* parent):
 
   // create proxy folder model to do item filtering
   proxyModel_ = new ProxyFolderModel();
-  proxyModel_->setShowHidden(false);
+  proxyModel_->setShowHidden(settings.showHidden());
   proxyModel_->setShowThumbnails(settings.showThumbnails());
   connect(proxyModel_, SIGNAL(sortFilterChanged()), SLOT(onModelSortFilterChanged()));
 


### PR DESCRIPTION
I don't understand why it was not done yet, but here it is.

I'm not sure if I called settings.save() in the right location, but here it is, and it fixes #56.
