### PR TITLE
Fixes enable/disable in wallpaper/background selection

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -80,7 +80,7 @@
            </widget>
           </item>
           <item row="5" column="0">
-           <widget class="QLabel" name="label_5">
+           <widget class="QLabel" name="backgroundColorLabel">
             <property name="text">
              <string>Select background color:</string>
             </property>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -75,6 +75,14 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   ui.textColor->setColor(settings.desktopFgColor());
   ui.shadowColor->setColor(settings.desktopShadowColor());
   ui.showWmMenu->setChecked(settings.showWmMenu());
+
+  if (i) { // Use wallpaper
+    ui.backgroundColor->setEnabled(false);
+    ui.backgroundColorLabel->setEnabled(false);
+  } else { // Use background color only
+    ui.imageFile->setEnabled(false);
+    ui.browse->setEnabled(false);
+  }
 }
 
 DesktopPreferencesDialog::~DesktopPreferencesDialog() {
@@ -108,6 +116,8 @@ void DesktopPreferencesDialog::onWallpaperModeChanged(int index) {
   bool enable = (mode != DesktopWindow::WallpaperNone);
   ui.imageFile->setEnabled(enable);
   ui.browse->setEnabled(enable);
+  ui.backgroundColor->setEnabled(!enable);
+  ui.backgroundColorLabel->setEnabled(!enable);
 }
 
 void DesktopPreferencesDialog::onBrowseClicked() {


### PR DESCRIPTION
When the user chooses the background color, the wallpaper selection widgets
should be disabled and vice-versa.
