### PR TITLE
Fix #111 - Can't change bookmarks

### DIFF
--- a/libfm-qt/editbookmarksdialog.cpp
+++ b/libfm-qt/editbookmarksdialog.cpp
@@ -75,7 +75,11 @@ void EditBookmarksDialog::accept() {
   }
 
   // FIXME: should we support Qt or KDE specific bookmarks in the future?
-  char* outputFile = g_build_filename(g_get_home_dir(), ".gtk-bookmarks", NULL);
+  char* outputFile = g_build_filename(g_get_user_config_dir(), "gtk-3.0", "bookmarks", NULL);
+  if (!g_file_test(outputFile, G_FILE_TEST_IS_REGULAR)) {
+    g_free(outputFile);
+    outputFile = g_build_filename(g_get_home_dir(), ".gtk-bookmarks", NULL);
+  }
   // we use glib API here because the API is atomic.
   g_file_set_contents(outputFile, buf.constData(), buf.length(), NULL);
   g_free(outputFile);


### PR DESCRIPTION
Fixes #111. `~/.gtk-bookmarks` is considered the legacy/fallback location for bookmarks in `libfm`, so the new location should be checked first before saving. See [`fm_bookmarks_init()`](https://github.com/lxde/libfm/blob/06424ed5c0b1e83c603b1c94bf15cae748b61d78/src/base/fm-bookmarks.c#L184) in `libfm` for comparison.