### PR TITLE
Remember maximized window state

### DIFF
--- a/pcmanfm/autorundialog.cpp
+++ b/pcmanfm/autorundialog.cpp
@@ -80,6 +80,9 @@ void AutoRunDialog::accept() {
       MainWindow* win = new MainWindow(path);
       fm_path_unref(path);
       win->resize(settings.windowWidth(), settings.windowHeight());
+      if(settings.windowMaximized()) {
+          win->setWindowState(win->windowState() | Qt::WindowMaximized);
+      }
       win->show();
     }
     g_object_unref(gf);

--- a/pcmanfm/launcher.cpp
+++ b/pcmanfm/launcher.cpp
@@ -42,6 +42,10 @@ bool Launcher::openFolder(GAppLaunchContext* ctx, GList* folder_infos, GError** 
   if(!mainWindow) {
     mainWindow = new MainWindow(fm_file_info_get_path(fi));
     mainWindow->resize(app->settings().windowWidth(), app->settings().windowHeight());
+
+    if(app->settings().windowMaximized()) {
+        mainWindow->setWindowState(mainWindow->windowState() | Qt::WindowMaximized);
+    }
   }
   else
     mainWindow->chdir(fm_file_info_get_path(fi));

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -263,6 +263,10 @@ void MainWindow::on_actionNewWin_triggered() {
   Application* app = static_cast<Application*>(qApp);
   MainWindow* newWin = new MainWindow(path);
   newWin->resize(app->settings().windowWidth(), app->settings().windowHeight());
+
+  if(app->settings().windowMaximized())
+  	newWin->setWindowState(newWin->windowState() | Qt::WindowMaximized);
+  
   newWin->show();
 }
 
@@ -454,8 +458,12 @@ void MainWindow::resizeEvent(QResizeEvent *event) {
   QMainWindow::resizeEvent(event);
   Settings& settings = static_cast<Application*>(qApp)->settings();
   if(settings.rememberWindowSize()) {
-    settings.setLastWindowWidth(width());
-    settings.setLastWindowHeight(height());
+    settings.setLastWindowMaximized(isMaximized());
+
+    if(!isMaximized()) {
+        settings.setLastWindowWidth(width());
+        settings.setLastWindowHeight(height());
+    }
   }
 }
 
@@ -464,8 +472,12 @@ void MainWindow::closeEvent(QCloseEvent *event)
   QWidget::closeEvent(event);
   Settings& settings = static_cast<Application*>(qApp)->settings();
   if(settings.rememberWindowSize()) {
-    settings.setLastWindowWidth(width());
-    settings.setLastWindowHeight(height());
+    settings.setLastWindowMaximized(isMaximized());
+
+    if(!isMaximized()) {
+        settings.setLastWindowWidth(width());
+        settings.setLastWindowHeight(height());
+    }
   }
 }
 
@@ -624,6 +636,10 @@ void MainWindow::onTabPageOpenDirRequested(FmPath* path, int target) {
     MainWindow* newWin = new MainWindow(path);
     // TODO: apply window size from app->settings
     newWin->resize(app->settings().windowWidth(), app->settings().windowHeight());
+    
+    if(app->settings().windowMaximized())
+        newWin->setWindowState(newWin->windowState() | Qt::WindowMaximized);
+    
     newWin->show();
     break;
   }

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -75,6 +75,7 @@ Settings::Settings():
   fixedWindowHeight_(480),
   lastWindowWidth_(640),
   lastWindowHeight_(480),
+  lastWindowMaximized_(false),
   splitterPos_(120),
   sidePaneMode_(0),
   viewMode_(Fm::FolderView::IconMode),
@@ -208,6 +209,7 @@ bool Settings::loadFile(QString filePath) {
   fixedWindowHeight_ = settings.value("FixedHeight", 480).toInt();
   lastWindowWidth_ = settings.value("LastWindowWidth", 640).toInt();
   lastWindowHeight_ = settings.value("LastWindowHeight", 480).toInt();
+  lastWindowMaximized_ = settings.value("LastWindowMaximized", false).toBool();
   rememberWindowSize_ = settings.value("RememberWindowSize", true).toBool();
   alwaysShowTabs_ = settings.value("AlwaysShowTabs", true).toBool();
   showTabClose_ = settings.value("ShowTabClose", true).toBool();
@@ -284,6 +286,7 @@ bool Settings::saveFile(QString filePath) {
   settings.setValue("FixedHeight", fixedWindowHeight_);
   settings.setValue("LastWindowWidth", lastWindowWidth_);
   settings.setValue("LastWindowHeight", lastWindowHeight_);
+  settings.setValue("LastWindowMaximized", lastWindowMaximized_);
   settings.setValue("RememberWindowSize", rememberWindowSize_);
   settings.setValue("AlwaysShowTabs", alwaysShowTabs_);
   settings.setValue("ShowTabClose", showTabClose_);

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -247,6 +247,13 @@ public:
       return fixedWindowHeight_;
   }
 
+  bool windowMaximized() const {
+    if(rememberWindowSize_)
+      return lastWindowMaximized_;
+    else
+      return false;
+  }
+
   int fixedWindowWidth() const {
     return fixedWindowWidth_;
   }
@@ -269,6 +276,10 @@ public:
 
   void setLastWindowHeight(int lastWindowHeight) {
       lastWindowHeight_ = lastWindowHeight;
+  }
+
+  void setLastWindowMaximized(bool lastWindowMaximized) {
+      lastWindowMaximized_ = lastWindowMaximized;
   }
 
   int splitterPos() const {
@@ -458,6 +469,7 @@ private:
   int fixedWindowHeight_;
   int lastWindowWidth_;
   int lastWindowHeight_;
+  bool lastWindowMaximized_;
   int splitterPos_;
   int sidePaneMode_;
 


### PR DESCRIPTION
At the moment only the window size is being saved but not the window's maximized state, if the "Remember the size of the last closed window" option is active. This patch adds the ability to open new windows not just with the last size but also the last maximized state.