### PR TITLE
Sort indicators in detailed view, fixes #109.

### DIFF
--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -195,6 +195,11 @@ FolderViewTreeView::~FolderViewTreeView() {
 void FolderViewTreeView::setModel(QAbstractItemModel* model) {
   QTreeView::setModel(model);
   layoutColumns();
+  if(ProxyFolderModel* proxyModel = qobject_cast<ProxyFolderModel*>(model)) {
+    connect(proxyModel, &ProxyFolderModel::sortFilterChanged, this, &FolderViewTreeView::onSortFilterChanged,
+            Qt::UniqueConnection);
+    onSortFilterChanged();
+  }
 }
 
 void FolderViewTreeView::mousePressEvent(QMouseEvent* event) {
@@ -343,6 +348,16 @@ void FolderViewTreeView::mouseDoubleClickEvent(QMouseEvent* event) {
 void FolderViewTreeView::activation(const QModelIndex &index) {
   if (activationAllowed_) {
     Q_EMIT activatedFiltered(index);
+  }
+}
+
+void FolderViewTreeView::onSortFilterChanged() {
+  if(QSortFilterProxyModel* proxyModel = qobject_cast<QSortFilterProxyModel*>(model())) {
+    header()->setSortIndicatorShown(true);
+    header()->setSortIndicator(proxyModel->sortColumn(), proxyModel->sortOrder());
+    if (!isSortingEnabled()) {
+      setSortingEnabled(true);
+    }
   }
 }
 

--- a/libfm-qt/folderview_p.h
+++ b/libfm-qt/folderview_p.h
@@ -94,6 +94,7 @@ Q_SIGNALS:
 private Q_SLOTS:
   void layoutColumns();
   void activation(const QModelIndex &index);
+  void onSortFilterChanged();
 
 private:
   bool doingLayout_;

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -653,6 +653,9 @@ void MainWindow::onTabPageSortFilterChanged() {
 
   if(tabPage == currentPage()) {
     updateViewMenuForCurrentPage();
+    Settings& settings = static_cast<Application*>(qApp)->settings();
+    settings.setSortColumn(static_cast<Fm::FolderModel::ColumnId>(tabPage->sortColumn()));
+    settings.setSortOrder(tabPage->sortOrder());
   }
 }
 

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -328,7 +328,9 @@ void TabPage::chdir(FmPath* newPath, bool addHistory) {
 
   folderModel_ = CachedFolderModel::modelFromFolder(folder_);
   proxyModel_->setSourceModel(folderModel_);
-  proxyModel_->sort(Fm::FolderModel::ColumnFileName);
+  proxyModel_->sort(proxyModel_->sortColumn(), proxyModel_->sortOrder());
+  Settings& settings = static_cast<Application*>(qApp)->settings();
+  proxyModel_->sort(settings.sortColumn(), settings.sortOrder());
 
   if(fm_folder_is_loaded(folder_)) {
     onFolderStartLoading(folder_, this);


### PR DESCRIPTION
It would be nice if the Qt-version had sort indicators on the headers of the table in detailed view, so that the columns could be sorted by clicking on the headers, not only using the menu. This commit implements this feature.