### PR TITLE
Fixes for warnings from static checks and memory leaks

### DIFF
--- a/libfm-qt/dirtreemodelitem.cpp
+++ b/libfm-qt/dirtreemodelitem.cpp
@@ -226,7 +226,6 @@ qDebug() << "folder loaded";
 void DirTreeModelItem::onFolderFilesAdded(FmFolder* folder, GSList* files, gpointer user_data) {
   GSList* l;
   DirTreeModelItem* _this = (DirTreeModelItem*)user_data;
-  DirTreeModel* model = _this->model_;
   for(l = files; l; l = l->next) {
     FmFileInfo* fi = FM_FILE_INFO(l->data);
     if(fm_file_info_is_dir(fi)) { /* FIXME: maybe adding files can be allowed later */

--- a/libfm-qt/dirtreeview.cpp
+++ b/libfm-qt/dirtreeview.cpp
@@ -98,7 +98,7 @@ void DirTreeView::onRowLoaded(const QModelIndex& index) {
   /* disconnect the handler since we only need it once */
   disconnect(_model, &DirTreeModel::rowLoaded, this, &DirTreeView::onRowLoaded);
 
-  DirTreeModelItem* item = _model->itemFromIndex(index);
+  // DirTreeModelItem* item = _model->itemFromIndex(index);
   // qDebug() << "row loaded: " << item->displayName_;
   /* after the folder is loaded, the files should have been added to
     * the tree model */
@@ -122,7 +122,7 @@ void DirTreeView::setCurrentPath(FmPath* path) {
   if(!_model)
     return;
   int rowCount = _model->rowCount(QModelIndex());
-  if(rowCount == 0 || fm_path_equal(currentPath_, path))
+  if(rowCount <= 0 || fm_path_equal(currentPath_, path))
     return;
 
   if(currentPath_)

--- a/libfm-qt/editbookmarksdialog.cpp
+++ b/libfm-qt/editbookmarksdialog.cpp
@@ -37,8 +37,8 @@ EditBookmarksDialog::EditBookmarksDialog(FmBookmarks* bookmarks, QWidget* parent
   setAttribute(Qt::WA_DeleteOnClose); // auto delete on close
 
   // load bookmarks
-  GList* l = fm_bookmarks_get_all(bookmarks_);
-  for(; l; l = l->next) {
+  GList* allBookmarks = fm_bookmarks_get_all(bookmarks_);
+  for(GList* l = allBookmarks; l; l = l->next) {
     FmBookmarkItem* bookmark = reinterpret_cast<FmBookmarkItem*>(l->data);
     QTreeWidgetItem* item = new QTreeWidgetItem();
     char* path_str = fm_path_display_name(bookmark->path, false);
@@ -48,6 +48,7 @@ EditBookmarksDialog::EditBookmarksDialog(FmBookmarks* bookmarks, QWidget* parent
     g_free(path_str);
     ui->treeWidget->addTopLevelItem(item);
   }
+  g_list_free_full(allBookmarks, (GDestroyNotify)fm_bookmark_item_unref);
 
   connect(ui->addItem, &QPushButton::clicked, this, &EditBookmarksDialog::onAddItem);
   connect(ui->removeItem, &QPushButton::clicked, this, &EditBookmarksDialog::onRemoveItem);

--- a/libfm-qt/filelauncher.h
+++ b/libfm-qt/filelauncher.h
@@ -34,11 +34,11 @@ public:
 
   bool launchFiles(QWidget* parent, FmFileInfoList* file_infos) {
     GList* fileList = fm_file_info_list_peek_head_link(file_infos);
-    return Fm::FileLauncher::launchFiles(parent, fileList);
+    return launchFiles(parent, fileList);
   }
   bool launchPaths(QWidget* parent, FmPathList* paths) {
     GList* pathList = fm_path_list_peek_head_link(paths);
-    return Fm::FileLauncher::launchPaths(parent, pathList);
+    return launchPaths(parent, pathList);
   }
 
   bool launchFiles(QWidget* parent, GList* file_infos);

--- a/libfm-qt/fileoperation.cpp
+++ b/libfm-qt/fileoperation.cpp
@@ -86,6 +86,7 @@ FileOperation::~FileOperation() {
 }
 
 bool FileOperation::run() {
+  delete uiTimer;
   // run the job
   uiTimer = new QTimer();
   uiTimer->start(SHOW_DLG_DELAY);

--- a/libfm-qt/folderitemdelegate.cpp
+++ b/libfm-qt/folderitemdelegate.cpp
@@ -53,8 +53,6 @@ QSize FolderItemDelegate::sizeHint(const QStyleOptionViewItem& option, const QMo
     initStyleOption(&opt, index);
     opt.decorationAlignment = Qt::AlignHCenter|Qt::AlignTop;
     opt.displayAlignment = Qt::AlignTop|Qt::AlignHCenter;
-    const QWidget* widget = opt.widget;
-    QStyle* style = widget ? widget->style() : QApplication::style();
 
     // FIXME: there're some problems in this size hint calculation.
     Q_ASSERT(gridSize_ != QSize());
@@ -132,9 +130,6 @@ void FolderItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& op
 
 // if painter is NULL, the method calculate the bounding rectangle of the text and save it to textRect
 void FolderItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& opt, QRectF& textRect) const {
-  const QWidget* widget = opt.widget;
-  QStyle* style = widget->style() ? widget->style() : qApp->style();
-  const int focusMargin = style->pixelMetric(QStyle::PM_FocusFrameHMargin, &opt, widget);
   QTextLayout layout(opt.text, opt.font);
   QTextOption textOption;
   textOption.setAlignment(opt.displayAlignment);
@@ -210,7 +205,10 @@ void FolderItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& opt
                   ? QPalette::Normal : QPalette::Disabled;
     o.backgroundColor = opt.palette.color(cg, (opt.state & QStyle::State_Selected)
                                   ? QPalette::Highlight : QPalette::Window);
-    style->drawPrimitive(QStyle::PE_FrameFocusRect, &o, painter, widget);
+    if (const QWidget* widget = opt.widget) {
+      QStyle* style = widget->style() ? widget->style() : qApp->style();
+      style->drawPrimitive(QStyle::PE_FrameFocusRect, &o, painter, widget);
+    }
   }
 }
 

--- a/libfm-qt/foldermodel.cpp
+++ b/libfm-qt/foldermodel.cpp
@@ -95,7 +95,8 @@ void FolderModel::onStartLoading(FmFolder* folder, gpointer user_data) {
 }
 
 void FolderModel::onFinishLoading(FmFolder* folder, gpointer user_data) {
-  FolderModel* model = static_cast<FolderModel*>(user_data);
+  Q_UNUSED(folder)
+  Q_UNUSED(user_data)
 }
 
 void FolderModel::onFilesAdded(FmFolder* folder, GSList* files, gpointer user_data) {
@@ -217,12 +218,10 @@ QVariant FolderModel::data(const QModelIndex & index, int role = Qt::DisplayRole
         case ColumnFileSize: {
           const char* name = fm_file_info_get_disp_size(info);
           return QString::fromUtf8(name);
-          break;
         }
         case ColumnFileOwner: {
           const char* name = fm_file_info_get_disp_owner(info);
           return QString::fromUtf8(name);
-          break;
         }
       }
     }

--- a/libfm-qt/foldermodel.cpp
+++ b/libfm-qt/foldermodel.cpp
@@ -119,7 +119,6 @@ void FolderModel::onFilesAdded(FmFolder* folder, GSList* files, gpointer user_da
 //static
 void FolderModel::onFilesChanged(FmFolder* folder, GSList* files, gpointer user_data) {
   FolderModel* model = static_cast<FolderModel*>(user_data);
-  int n_files = g_slist_length(files);
   for(GSList* l = files; l; l = l->next) {
     FmFileInfo* info = FM_FILE_INFO(l->data);
     int row;

--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -696,7 +696,7 @@ FmFileInfoList* FolderView::selectedFiles() const {
     if(!selIndexes.isEmpty()) {
       FmFileInfoList* files = fm_file_info_list_new();
       QModelIndexList::const_iterator it;
-      for(it = selIndexes.constBegin(); it != selIndexes.constEnd(); it++) {
+      for(it = selIndexes.constBegin(); it != selIndexes.constEnd(); ++it) {
         FmFileInfo* file = model_->fileInfoFromIndex(*it);
         fm_file_info_list_push_tail(files, file);
       }

--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -267,12 +267,10 @@ void FolderViewTreeView::layoutColumns() {
       // even when we reduce the width of the filename column to 200,
       // the available space is not enough. So we give up trying.
       widths[filenameColumn] = 200;
-      desiredWidth += 200;
     }
     else { // we still have more space, so the width of filename column can be increased
       // expand the filename column to fill all available space.
       widths[filenameColumn] = availWidth - desiredWidth;
-      desiredWidth = availWidth;
     }
   }
 
@@ -920,8 +918,6 @@ void FolderView::onFileClicked(int type, FmFileInfo* fileInfo) {
       }
     }
     else {
-      FmFolder* _folder = folder();
-      FmFileInfo* info = fm_folder_get_info(_folder);
       Fm::FolderMenu* folderMenu = new Fm::FolderMenu(this);
       prepareFolderMenu(folderMenu);
       menu = folderMenu;

--- a/libfm-qt/libfmqt.cpp
+++ b/libfm-qt/libfmqt.cpp
@@ -33,6 +33,7 @@ struct LibFmQtData {
   ThumbnailLoader* thumbnailLoader;
   QTranslator translator;
   int refCount;
+  Q_DISABLE_COPY(LibFmQtData)
 };
 
 static LibFmQtData* theLibFmData = NULL;

--- a/libfm-qt/placesmodel.cpp
+++ b/libfm-qt/placesmodel.cpp
@@ -37,7 +37,6 @@ PlacesModel::PlacesModel(QObject* parent):
 
   setColumnCount(2);
 
-  PlacesModelItem* item;
   placesRoot = new QStandardItem(tr("Places"));
   placesRoot->setSelectable(false);
   placesRoot->setColumnCount(2);
@@ -118,7 +117,7 @@ PlacesModel::PlacesModel(QObject* parent):
         if(volume)
         g_object_unref(volume);
         else { /* network mounts or others */
-        item = new PlacesModelMountItem(mount);
+        PlacesModelItem* item = new PlacesModelMountItem(mount);
         devicesRoot->appendRow(item);
         }
         g_object_unref(mount);

--- a/libfm-qt/placesmodelitem.cpp
+++ b/libfm-qt/placesmodelitem.cpp
@@ -130,7 +130,9 @@ PlacesModelVolumeItem::PlacesModelVolumeItem(GVolume* volume):
 
 void PlacesModelVolumeItem::update() {
   // set title
-  setText(QString::fromUtf8(g_volume_get_name(volume_)));
+  char* volumeName = g_volume_get_name(volume_);
+  setText(QString::fromUtf8(volumeName));
+  g_free(volumeName);
   
   // set icon
   GIcon* gicon = g_volume_get_icon(volume_);

--- a/libfm-qt/placesview.cpp
+++ b/libfm-qt/placesview.cpp
@@ -240,7 +240,6 @@ void PlacesView::onUnmountVolume() {
   if(!action->index().isValid())
     return;
   PlacesModelVolumeItem* item = static_cast<PlacesModelVolumeItem*>(model_->itemFromIndex(action->index()));
-  GMount* mount = NULL;
   MountOperation* op = new MountOperation(true, this);
   op->unmount(item->volume());
   op->wait();

--- a/libfm-qt/proxyfoldermodel.cpp
+++ b/libfm-qt/proxyfoldermodel.cpp
@@ -227,8 +227,8 @@ QVariant ProxyFolderModel::data(const QModelIndex& index, int role) const {
 
 void ProxyFolderModel::onThumbnailLoaded(const QModelIndex& srcIndex, int size) {
   
-  FolderModel* srcModel = static_cast<FolderModel*>(sourceModel());
-  FolderModelItem* item = srcModel->itemFromIndex(srcIndex);
+  // FolderModel* srcModel = static_cast<FolderModel*>(sourceModel());
+  // FolderModelItem* item = srcModel->itemFromIndex(srcIndex);
   // qDebug("ProxyFolderModel::onThumbnailLoaded: %d, %s", size, item->displayName.toUtf8().data());
   
   if(size == thumbnailSize_) { // if a thumbnail of the size we want is loaded

--- a/libfm-qt/proxyfoldermodel.h
+++ b/libfm-qt/proxyfoldermodel.h
@@ -43,8 +43,6 @@ public:
 class LIBFM_QT_API ProxyFolderModel : public QSortFilterProxyModel {
   Q_OBJECT
 public:
-
-public:
   explicit ProxyFolderModel(QObject * parent = 0);
   virtual ~ProxyFolderModel();
 

--- a/libfm-qt/thumbnailloader.cpp
+++ b/libfm-qt/thumbnailloader.cpp
@@ -82,7 +82,6 @@ bool ThumbnailLoader::localFilesOnly_ = true;
 int ThumbnailLoader::maxThumbnailFileSize_ = 0;
 
 ThumbnailLoader::ThumbnailLoader() {
-  gboolean success;
   // apply the settings to libfm
   fm_config->thumbnail_local = localFilesOnly_;
   fm_config->thumbnail_max = maxThumbnailFileSize_;
@@ -98,7 +97,7 @@ ThumbnailLoader::ThumbnailLoader() {
     getImageText,
     setImageText
   };
-  success = fm_thumbnail_loader_set_backend(&qt_backend);
+  gboolean success = fm_thumbnail_loader_set_backend(&qt_backend);
 }
 
 ThumbnailLoader::~ThumbnailLoader() {

--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -699,7 +699,6 @@ void Application::onVirtualGeometryChanged(const QRect& rect) {
   // virtualGeometryChanged() is emitted correctly when the workAreas changed.
   // So we use it in Qt5.
   if(enableDesktopManager_) {
-    QScreen* screeb = static_cast<QScreen*>(sender());
     // qDebug() << "onVirtualGeometryChanged";
     Q_FOREACH(DesktopWindow* desktop, desktopWindows_) {
       desktop->queueRelayout();

--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -659,7 +659,6 @@ void Application::onScreenDestroyed(QObject* screenObj) {
   //
   // The workaround is very simple. Just completely destroy the window before Qt has a chance to do
   // QWindow::setScreen() for it. Later, we recreate the window ourselves. So this can bypassing the Qt bugs.
-  QScreen* screen = static_cast<QScreen*>(screenObj);
   if(enableDesktopManager_) {
     bool reloadNeeded = false;
     // FIXME: add workarounds for Qt5 bug #40681 and #40791 here.

--- a/pcmanfm/desktopitemdelegate.cpp
+++ b/pcmanfm/desktopitemdelegate.cpp
@@ -42,8 +42,6 @@ void DesktopItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
   Q_ASSERT(index.isValid());
   QStyleOptionViewItemV4 opt = option;
   initStyleOption(&opt, index);
-  const QWidget* widget = opt.widget;
-  QStyle* style = widget ? widget->style() : QApplication::style();
 
   painter->save();
   painter->setClipRect(option.rect);
@@ -112,8 +110,8 @@ void DesktopItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
   QRectF boundRect = layout.boundingRect();
   boundRect.setWidth(width);
   boundRect.moveTo(textRect.x() + (textRect.width() - width)/2, textRect.y());
-  if(opt.state & QStyle::State_Selected) {
-    QPalette palette = widget->palette();
+  if((opt.state & QStyle::State_Selected) && opt.widget) {
+    QPalette palette = opt.widget->palette();
     // qDebug("w: %f, h:%f, m:%f", boundRect.width(), boundRect.height(), layout.minimumWidth());
     painter->fillRect(boundRect, palette.highlight());
   }
@@ -158,8 +156,6 @@ QSize DesktopItemDelegate::sizeHint(const QStyleOptionViewItem& option, const QM
     return qvariant_cast<QSize>(value);
   QStyleOptionViewItemV4 opt = option;
   initStyleOption(&opt, index);
-  const QWidget* widget = opt.widget;
-  QStyle* style = widget ? widget->style() : QApplication::style();
 
   // use grid size as size hint
   QSize gridSize = view_->gridSize();

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -158,7 +158,6 @@ void DesktopPreferencesDialog::accept() {
 }
 
 void DesktopPreferencesDialog::onWallpaperModeChanged(int index) {
-  int n = ui.wallpaperMode->count();
   int mode = ui.wallpaperMode->itemData(index).toInt();
 
   bool enable = (mode != DesktopWindow::WallpaperNone);

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -674,17 +674,18 @@ void MainWindow::onSplitterMoved(int pos, int index) {
 }
 
 void MainWindow::loadBookmarksMenu() {
-  GList* l = fm_bookmarks_get_all(bookmarks);
+  GList* allBookmarks = fm_bookmarks_get_all(bookmarks);
   QAction* before = ui.actionAddToBookmarks;
 
-  for(; l; l = l->next) {
+  for(GList* l = allBookmarks; l; l = l->next) {
     FmBookmarkItem* item = reinterpret_cast<FmBookmarkItem*>(l->data);
-    BookmarkAction* action = new BookmarkAction(item);
+    BookmarkAction* action = new BookmarkAction(item, ui.menu_Bookmarks);
     connect(action, &QAction::triggered, this, &MainWindow::onBookmarkActionTriggered);
     ui.menu_Bookmarks->insertAction(before, action);
   }
 
   ui.menu_Bookmarks->insertSeparator(before);
+  g_list_free_full(allBookmarks, (GDestroyNotify)fm_bookmark_item_unref);
 }
 
 void MainWindow::onBookmarksChanged(FmBookmarks* bookmarks, MainWindow* pThis) {

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -81,8 +81,6 @@ static void findIconThemesInDir(QHash<QString, QString>& iconThemes, QString dir
 }
 
 void PreferencesDialog::initIconThemes(Settings& settings) {
-  Application* app = static_cast<Application*>(qApp);
-
   // check if auto-detection is done (for example, from xsettings)
   if(settings.useFallbackIconTheme()) { // auto-detection failed
     // load xdg icon themes and select the current one

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -71,6 +71,7 @@ Settings::Settings():
   desktopSortColumn_(Fm::FolderModel::ColumnFileName),
   alwaysShowTabs_(true),
   showTabClose_(true),
+  rememberWindowSize_(true),
   fixedWindowWidth_(640),
   fixedWindowHeight_(480),
   lastWindowWidth_(640),

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -382,15 +382,13 @@ void TabPage::onSelChanged(int numSel) {
       fm_file_info_list_unref(files);
     }
     else {
-      FmFileInfoList* files;
       goffset sum;
       GList* l;
-      char size_str[128];
       msg = tr("%1 item(s) selected", NULL, numSel).arg(numSel);
       /* don't count if too many files are selected, that isn't lightweight */
       if(numSel < 1000) {
         sum = 0;
-        files = folderView_->selectedFiles();
+        FmFileInfoList* files = folderView_->selectedFiles();
         for(l = fm_file_info_list_peek_head_link(files); l; l = l->next) {
           if(fm_file_info_is_dir(FM_FILE_INFO(l->data))) {
             /* if we got a directory then we cannot tell it's size
@@ -401,6 +399,7 @@ void TabPage::onSelChanged(int numSel) {
           sum += fm_file_info_get_size(FM_FILE_INFO(l->data));
         }
         if(sum >= 0) {
+          char size_str[128];
           fm_file_size_to_str(size_str, sizeof(size_str), sum,
                               fm_config->si_unit);
 	  msg += QString(" (%1)").arg(QString::fromUtf8(size_str));

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -342,7 +342,6 @@ void TabPage::chdir(FmPath* newPath, bool addHistory) {
 
   if(addHistory) {
     // add current path to browse history
-    QAbstractItemView* childView = folderView_->childView();
     history_.add(path());
   }
 }


### PR DESCRIPTION
I ran the pcmanfm-qt code through some analyzers (scan-build from clang, cppcheck and memcheck from valgrind). The issues found by the static code analysis are mainly some lines with unused codes. The commits remove these lines.

cppcheck also showed some unused functions. I did not touch them because these functions may be there to be completed, and since libfm-qt is a library, unused code there just means that the corresponding functions are not used by pcmanfm-qt. Just for your information, here is a list of the unused functions, with false results removed:

pcmanfm-qt:

```
Application::nativeEventFilter()
Application::onLastWindowClosed()
Application::onSaveStateRequest()
ProxyFolderModel::addFilter(), ProxyFolderModel::removeFilter(),
ProxyFolderModel::filters_, everything using ProxyFolderModelFilter
Settings::bookmarkOpenMethod(), Settings::setBookmarkOpenMethod(),
Settings::bookmarkOpenMethod_
Settings::sidePaneModeToString(), Settings::sidePaneMode_ is not really used
View::onSearch()
```

libfm-qt:

```
AppChooserDialog::isSetDefault()
AppMenuView::selectedAppDesktopFilePath()
AppMenuView::selectedAppDesktopPath()
BrowseHistory::setMaxCount()
DirTreeModel::indexFromPath()
DirTreeModel::isLoaded()
DndDest::isSupported()
Fm::isUriSchemeSupported()
FolderModel::findItemByPath()
PlacesModel::itemFromBookmark()
PlacesModel::setShowApplications()
PlacesModel::setShowDesktop()
PlacesModel::setShowTrash()
PlacesModelItem::setFileInfo()
SidePane::modeByName()
SidePane::modeName()
SidePane::setHomeDir()
```

Regarding the memory leaks found by valgrind, note that only leaks in executed code are found, there are possibly still some more leaks in code which was not executed. This is especially true for unused code. For instance, I suppose that the `allBookmarks` GList in PlacesModel::dropMimeData() would leak, but I was not able to reach this code (I tried to move some files to the side pane, but this had no effect).

There is a leak which only occurs if one of the Tools menu items (Open Terminal, Open as root) is triggered. It concerns a bunch of GLib connections (slots onTrashChanged, onVolumeAdded, onVolumeRemoved, onVolumeChanged, onMountAdded, onMountChanged, onMountRemoved, onBookmarksChanged, onFolderStartLoading, onFolderFinishLoading, onFolderError, onFolderFsInfo, onFolderRemoved, onFolderUnmount, onFolderContentChanged, onStartLoading, onFinishLoading, onFilesAdded, onFilesChanged, onFilesRemoved, onVolumeAdded), the allocation is in `g_signal_connect()` and the deallocation in `g_signal_handlers_disconnect_by_func()` does not happen. I suppose that the execution of `fm_terminal_launch()` will fork and execute a system call from the exec family. I do not know the GLib/GTK work good enough to have a solution ready for this, maybe some kind of `atexit` call which would disconnect all these connections.
