### PR TITLE
Fix loading new desktop dir

### DIFF
--- a/pcmanfm/CMakeLists.txt
+++ b/pcmanfm/CMakeLists.txt
@@ -26,6 +26,7 @@ set(pcmanfm_SRCS
     view.cpp
     launcher.cpp
     preferencesdialog.cpp
+    xdgdir.cpp
     desktoppreferencesdialog.cpp
     desktopwindow.cpp
     desktopitemdelegate.cpp

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -48,6 +48,7 @@
 #include "filepropsdialog.h"
 #include "utilities.h"
 #include "path.h"
+#include "xdgdir.h"
 
 #include <QX11Info>
 #include <QScreen>
@@ -198,7 +199,8 @@ void DesktopWindow::resizeEvent(QResizeEvent* event) {
 }
 
 void DesktopWindow::setDesktopFolder() {
-  model_ = Fm::CachedFolderModel::modelFromPath(fm_path_get_desktop());
+  FmPath *path = fm_path_new_for_path(XdgDir::readDesktopDir().toStdString().c_str());
+  model_ = Fm::CachedFolderModel::modelFromPath(path);
   proxyModel_->setSourceModel(model_);
 }
 
@@ -697,7 +699,11 @@ bool DesktopWindow::event(QEvent* event)
   case QEvent::FontChange:
     queueRelayout();
     break;
+
+  default:
+      break;
   }
+
   return QWidget::event(event);
 }
 

--- a/pcmanfm/xdgdir.cpp
+++ b/pcmanfm/xdgdir.cpp
@@ -1,0 +1,72 @@
+/*
+ *    Copyright (C) 2013  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 2 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License along
+ *    with this program; if not, write to the Free Software Foundation, Inc.,
+ *    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "xdgdir.h"
+#include <QStandardPaths>
+#include <QFile>
+#include <QDir>
+#include <QSaveFile>
+
+QString XdgDir::readUserDirsFile() {
+    QFile file(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QStringLiteral("/user-dirs.dirs"));
+    if(file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QByteArray data = file.readAll();
+        file.close();
+        return QString::fromLocal8Bit(data);
+    }
+    return QString();
+}
+
+QString XdgDir::readDesktopDir() {
+    QString str = readUserDirsFile();
+    if(str.isEmpty())
+        return QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + QStringLiteral("/Desktop");
+    QRegExp reg(QStringLiteral("XDG_DESKTOP_DIR=\"([^\n]*)\""));
+    if(reg.lastIndexIn(str) != -1) {
+        str = reg.cap(1);
+        if(str.startsWith(QStringLiteral("$HOME")))
+            str = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + str.mid(5);
+        return str;
+    }
+    return QString();
+}
+
+void XdgDir::setDesktopDir(QString path) {
+    QString home = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+    if(path.startsWith(home))
+        path = QStringLiteral("$HOME") + path.mid(home.length());
+    QString str = readUserDirsFile();
+    QRegExp reg(QStringLiteral("XDG_DESKTOP_DIR=\"([^\n]*)\""));
+    QString line = QStringLiteral("XDG_DESKTOP_DIR=\"") + path + '\"';
+    if(reg.indexIn(str) != -1)
+        str.replace(reg, line);
+    else {
+        if(!str.endsWith('\n'))
+            str += '\n';
+        str += line + '\n';
+    }
+    QString dir = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+    if(QDir().mkpath(dir)) { // write the file
+        QSaveFile file(dir + QStringLiteral("/user-dirs.dirs"));
+        if(file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+            file.write(str.toLocal8Bit());
+            file.commit();
+        }
+    }
+}
+

--- a/pcmanfm/xdgdir.h
+++ b/pcmanfm/xdgdir.h
@@ -1,0 +1,33 @@
+/*
+ *    Copyright (C) 2013  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 2 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License along
+ *    with this program; if not, write to the Free Software Foundation, Inc.,
+ *    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <QObject>
+#include <QString>
+
+class XdgDir : public QObject
+{
+    Q_OBJECT
+
+public:
+    static QString readDesktopDir();
+
+    static void setDesktopDir(QString path);
+
+private:
+    static QString readUserDirsFile();
+};


### PR DESCRIPTION
Do not rely on `fm_path_get_desktop()` as it doesn't get updated values from `~/.config/user-dirs.dirs`. Use pcmanfm-qt's own parser for the config file.

Fixes lxde/lxqt#541