### PR TITLE
Add menu items and shortcuts for new folder and blank file, fixes #163.

### DIFF
--- a/libfm-qt/foldermenu.cpp
+++ b/libfm-qt/foldermenu.cpp
@@ -267,14 +267,14 @@ void FolderMenu::onCreateNewFile() {
   FmPath* dirPath = view_->path();
 
   if(dirPath)
-    createFile(CreateNewTextFile, dirPath);
+    createFileOrFolder(CreateNewTextFile, dirPath);
 }
 
 void FolderMenu::onCreateNewFolder() {
   FmPath* dirPath = view_->path();
 
   if(dirPath)
-    createFile(CreateNewFolder, dirPath);
+    createFileOrFolder(CreateNewFolder, dirPath);
 }
 
 void FolderMenu::onCreateNew() {
@@ -292,7 +292,7 @@ void FolderMenu::onCreateNew() {
   if(templ) { // template found
     FmPath* dirPath = view_->path();
     if(dirPath)
-      createFile(CreateWithTemplate, dirPath, templ, view_);
+      createFileOrFolder(CreateWithTemplate, dirPath, templ, view_);
   }
 }
 

--- a/libfm-qt/utilities.cpp
+++ b/libfm-qt/utilities.cpp
@@ -158,9 +158,11 @@ void renameFile(FmFileInfo *file, QWidget *parent) {
 }
 
 // templateFile is a file path used as a template of the new file.
-void createFile(CreateFileType type, FmPath* parentDir, FmTemplate* templ, QWidget* parent) {
+void createFileOrFolder(CreateFileType type, FmPath* parentDir, FmTemplate* templ, QWidget* parent) {
   QString defaultNewName;
   QString prompt;
+  QString dialogTitle = type == CreateNewFolder ? QObject::tr("Create Folder")
+                                                : QObject::tr("Create File");
 
   switch(type) {
   case CreateNewTextFile:
@@ -184,7 +186,7 @@ void createFile(CreateFileType type, FmPath* parentDir, FmTemplate* templ, QWidg
 _retry:
   // ask the user to input a file name
   bool ok;
-  QString new_name = QInputDialog::getText(parent, QObject::tr("Create File"),
+  QString new_name = QInputDialog::getText(parent, dialogTitle,
                      prompt,
                      QLineEdit::Normal,
                      defaultNewName,

--- a/libfm-qt/utilities.h
+++ b/libfm-qt/utilities.h
@@ -48,7 +48,7 @@ enum CreateFileType {
   CreateWithTemplate
 };
 
-LIBFM_QT_API void createFile(CreateFileType type, FmPath* parentDir, FmTemplate* templ = NULL, QWidget* parent = 0);
+LIBFM_QT_API void createFileOrFolder(CreateFileType type, FmPath* parentDir, FmTemplate* templ = NULL, QWidget* parent = 0);
 
 LIBFM_QT_API uid_t uidFromName(QString name);
 

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -74,8 +74,17 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
+    <widget class="QMenu" name="menuCreateNew">
+     <property name="title">
+      <string>C&amp;reate New</string>
+     </property>
+     <addaction name="actionNewFolder"/>
+     <addaction name="actionNewBlankFile"/>
+    </widget>
     <addaction name="actionNewTab"/>
     <addaction name="actionNewWin"/>
+    <addaction name="separator"/>
+    <addaction name="menuCreateNew"/>
     <addaction name="separator"/>
     <addaction name="actionFileProperties"/>
     <addaction name="actionFolderProperties"/>
@@ -626,6 +635,25 @@
   <action name="actionEditBookmarks">
    <property name="text">
     <string>&amp;Edit Bookmarks</string>
+   </property>
+  </action>
+  <action name="actionNewFolder">
+   <property name="icon">
+    <iconset theme="folder-new"/>
+   </property>
+   <property name="text">
+    <string>Folder</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+N</string>
+   </property>
+  </action>
+  <action name="actionNewBlankFile">
+   <property name="text">
+    <string>Blank File</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Alt+N</string>
    </property>
   </action>
  </widget>

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -276,6 +276,24 @@ void MainWindow::on_actionNewWin_triggered() {
   newWin->show();
 }
 
+void MainWindow::on_actionNewFolder_triggered() {
+  if(TabPage* tabPage = currentPage()) {
+    FmPath* dirPath = tabPage->folderView()->path();
+
+    if(dirPath)
+      createFileOrFolder(CreateNewFolder, dirPath);
+  }
+}
+
+void MainWindow::on_actionNewBlankFile_triggered() {
+  if(TabPage* tabPage = currentPage()) {
+    FmPath* dirPath = tabPage->folderView()->path();
+
+    if(dirPath)
+      createFileOrFolder(CreateNewTextFile, dirPath);
+  }
+}
+
 void MainWindow::on_actionCloseTab_triggered() {
   closeTab(ui.tabBar->currentIndex());
 }

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -59,6 +59,8 @@ protected Q_SLOTS:
 
   void on_actionNewTab_triggered();
   void on_actionNewWin_triggered();
+  void on_actionNewFolder_triggered();
+  void on_actionNewBlankFile_triggered();
   void on_actionCloseTab_triggered();
   void on_actionCloseWindow_triggered();
   void on_actionFileProperties_triggered();


### PR DESCRIPTION
In detailed list view mode, it is only possible to create a new folder if there are less file entries than would fit into the window and the context menu can be activated in the empty space. This commit adds the "Create New" menu as we have it in the GTK version of pcmanfm. This adds also keyboard shortcuts as requested in issue #163.