### PR TITLE
Update column layout also if folder already loaded, fixes #190.

### DIFF
--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -535,6 +535,12 @@ void FolderView::setViewMode(ViewMode _mode) {
   }
 }
 
+void FolderView::updateAfterFolderLoaded() {
+  if(FolderViewTreeView* treeView = qobject_cast<FolderViewTreeView*>(view)) {
+    treeView->queueLayoutColumns();
+  }
+}
+
 // set proper grid size for the QListView based on current view mode, icon size, and font size.
 void FolderView::updateGridSize() {
   if(mode == DetailedListMode || !view)

--- a/libfm-qt/folderview.h
+++ b/libfm-qt/folderview.h
@@ -100,6 +100,8 @@ public:
 
   void invertSelection();
 
+  void updateAfterFolderLoaded();
+
   void setFileLauncher(FileLauncher* launcher) {
     fileLauncher_ = launcher;
   }

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -174,6 +174,8 @@ void TabPage::restoreScrollPos() {
   }
   qDebug("finish-loading");
 
+  pThis->folderView_->updateAfterFolderLoaded();
+
   // After finishing loading the folder, the model is updated, but Qt delays the UI update
   // for performance reasons. Therefore at this point the UI is not up to date.
   // Of course, the scrollbar ranges are not updated yet. We solve this by installing an Qt timeout handler.


### PR DESCRIPTION
An easier fix would be to connect `modelReset()` of the folder model to `FolderViewTreeView::queueLayoutColumns()`, however, this would bring some unneeded calls to `FolderViewTreeView::layoutColumns()`. The proposed solution will not cause such unneeded calls.