### PR TITLE
Paste into the folder when using its context menu for pasting.

### DIFF
--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -712,6 +712,18 @@ FmPathList* FolderView::selectedFilePaths() const {
   return NULL;
 }
 
+QModelIndex FolderView::indexFromFolderPath(FmPath* folderPath) const {
+  QModelIndex index;
+  int count = model_->rowCount();
+  for(int row = 0; row < count; ++row) {
+    index = model_->index(row, 0);
+    FmFileInfo* info = model_->fileInfoFromIndex(index);
+    if(info && fm_file_info_is_dir(info) && fm_path_equal(folderPath,fm_file_info_get_path(info)))
+      return index;
+  }
+  return QModelIndex();
+}
+
 FmFileInfoList* FolderView::selectedFiles() const {
   if(model_) {
     QModelIndexList selIndexes = mode == DetailedListMode ? selectedRows() : selectedIndexes();

--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -927,7 +927,13 @@ void FolderView::onFileClicked(int type, FmFileInfo* fileInfo) {
     }
   }
   else if(type == ContextMenuClick) {
-    FmPath* folderPath = path();
+    FmPath* folderPath = NULL;
+    FmFileInfoList* files = selectedFiles();
+    FmFileInfo* first = fm_file_info_list_peek_head(files);
+    if (fm_file_info_list_get_length(files) == 1 && fm_file_info_is_dir(first))
+      folderPath = fm_file_info_get_path(first);
+    else
+      folderPath = path();
     QMenu* menu = NULL;
     if(fileInfo) {
       // show context menu

--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -941,9 +941,11 @@ void FolderView::onFileClicked(int type, FmFileInfo* fileInfo) {
   else if(type == ContextMenuClick) {
     FmPath* folderPath = NULL;
     FmFileInfoList* files = selectedFiles();
-    FmFileInfo* first = fm_file_info_list_peek_head(files);
-    if (fm_file_info_list_get_length(files) == 1 && fm_file_info_is_dir(first))
-      folderPath = fm_file_info_get_path(first);
+    if (files) {
+      FmFileInfo* first = fm_file_info_list_peek_head(files);
+      if (fm_file_info_list_get_length(files) == 1 && fm_file_info_is_dir(first))
+        folderPath = fm_file_info_get_path(first);
+    }
     else
       folderPath = path();
     QMenu* menu = NULL;

--- a/libfm-qt/folderview.h
+++ b/libfm-qt/folderview.h
@@ -95,6 +95,7 @@ public:
   QItemSelectionModel* selectionModel() const;
   FmFileInfoList* selectedFiles() const;
   FmPathList* selectedFilePaths() const;
+  QModelIndex indexFromFolderPath(FmPath* folderPath) const;
 
   void selectAll();
 

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -31,7 +31,6 @@
 #include "application.h"
 #include "cachedfoldermodel.h"
 #include <QTimer>
-
 using namespace Fm;
 
 namespace PCManFM {
@@ -123,10 +122,24 @@ void TabPage::freeFolder() {
 #endif
 }
 
+static bool focusChildFolder(false);
+
 // slot
 void TabPage::restoreScrollPos() {
-  // scroll to recorded position
-  folderView_->childView()->verticalScrollBar()->setValue(browseHistory().currentScrollPos());
+  if (!focusChildFolder) {
+    // scroll to recorded position
+    folderView_->childView()->verticalScrollBar()->setValue(browseHistory().currentScrollPos());
+  } else {
+    // scroll to and select the folder from where we've come here by going up (-> up()).
+    focusChildFolder = false;
+    int prevIndex = history_.currentIndex() - 1;
+    if (prevIndex < 0) return;
+    QModelIndex index = folderView_->indexFromFolderPath(history_.at(prevIndex).path());
+    if (index.isValid()) {
+      folderView_->childView()->scrollTo(index, QAbstractItemView::EnsureVisible);
+      folderView_->childView()->setCurrentIndex(index);
+    }
+  }
 }
 
 /*static*/ void TabPage::onFolderFinishLoading(FmFolder* _folder, TabPage* pThis) {
@@ -319,6 +332,10 @@ void TabPage::chdir(FmPath* newPath, bool addHistory) {
   g_free(disp_name);
 
   folder_ = fm_folder_from_path(newPath);
+  if(addHistory) {
+    // add current path to browse history
+    history_.add(path());
+  }
   g_signal_connect(folder_, "start-loading", G_CALLBACK(onFolderStartLoading), this);
   g_signal_connect(folder_, "finish-loading", G_CALLBACK(onFolderFinishLoading), this);
   g_signal_connect(folder_, "error", G_CALLBACK(onFolderError), this);
@@ -342,11 +359,6 @@ void TabPage::chdir(FmPath* newPath, bool addHistory) {
   }
   else
     onFolderStartLoading(folder_, this);
-
-  if(addHistory) {
-    // add current path to browse history
-    history_.add(path());
-  }
 }
 
 void TabPage::selectAll() {
@@ -460,8 +472,10 @@ void TabPage::up() {
   FmPath* _path = path();
   if(_path) {
     FmPath* parent = fm_path_get_parent(_path);
-    if(parent)
+    if(parent) {
+      focusChildFolder = true;
       chdir(parent, true);
+    }
   }
 }
 


### PR DESCRIPTION
When a single folder is right clicked and the "Paste" item on its context menu is used, the copied/cut items aren't pasted into it but into the currently open folder (containing it). This commit makes them be pasted into the right clicked folder.

If MULTIPLE folders/files are right clicked, the copied/cut items will be pasted into the currently open folder, as before.