### PR TITLE
Paste into folder from its context menu.

### DIFF
--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -927,7 +927,15 @@ void FolderView::onFileClicked(int type, FmFileInfo* fileInfo) {
     }
   }
   else if(type == ContextMenuClick) {
-    FmPath* folderPath = path();
+    FmPath* folderPath = NULL;
+    FmFileInfoList* files = selectedFiles();
+    if (files) {
+      FmFileInfo* first = fm_file_info_list_peek_head(files);
+      if (fm_file_info_list_get_length(files) == 1 && fm_file_info_is_dir(first))
+        folderPath = fm_file_info_get_path(first);
+    }
+    if (!folderPath)
+      folderPath = path();
     QMenu* menu = NULL;
     if(fileInfo) {
       // show context menu


### PR DESCRIPTION
When a single folder was right clicked and the "Paste" item on its context menu was used, the copied/cut items weren't pasted into it but into the currently open folder (containing it). This commit makes them be pasted into the right clicked folder.

If MULTIPLE folders/files are right clicked, the copied/cut items will be pasted into the currently open folder, as before.