### PR TITLE
Select the folder from where we have gone up.

### DIFF
--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -712,6 +712,18 @@ FmPathList* FolderView::selectedFilePaths() const {
   return NULL;
 }
 
+QModelIndex FolderView::indexFromFolderPath(FmPath* folderPath) const {
+  QModelIndex index;
+  int count = model_->rowCount();
+  for(int row = 0; row < count; ++row) {
+    index = model_->index(row, 0);
+    FmFileInfo* info = model_->fileInfoFromIndex(index);
+    if(info && fm_file_info_is_dir(info) && fm_path_equal(folderPath,fm_file_info_get_path(info)))
+      return index;
+  }
+  return QModelIndex();
+}
+
 FmFileInfoList* FolderView::selectedFiles() const {
   if(model_) {
     QModelIndexList selIndexes = mode == DetailedListMode ? selectedRows() : selectedIndexes();

--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -713,6 +713,7 @@ FmPathList* FolderView::selectedFilePaths() const {
 }
 
 QModelIndex FolderView::indexFromFolderPath(FmPath* folderPath) const {
+  if(!model_ || !folderPath) return QModelIndex();
   QModelIndex index;
   int count = model_->rowCount();
   for(int row = 0; row < count; ++row) {

--- a/libfm-qt/folderview.h
+++ b/libfm-qt/folderview.h
@@ -95,6 +95,7 @@ public:
   QItemSelectionModel* selectionModel() const;
   FmFileInfoList* selectedFiles() const;
   FmPathList* selectedFilePaths() const;
+  QModelIndex indexFromFolderPath(FmPath* folderPath) const;
 
   void selectAll();
 

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -40,7 +40,8 @@ TabPage::TabPage(FmPath* path, QWidget* parent):
   QWidget(parent),
   folder_(NULL),
   folderModel_(NULL),
-  overrideCursor_(false) {
+  overrideCursor_(false),
+  wentUp_(false) {
 
   Settings& settings = static_cast<Application*>(qApp)->settings();
 
@@ -123,16 +124,14 @@ void TabPage::freeFolder() {
 #endif
 }
 
-static bool wentUp(false);
-
 // slot
 void TabPage::restoreScrollPos() {
-  if (!wentUp) {
+  if (!wentUp_) {
     // scroll to recorded position
     folderView_->childView()->verticalScrollBar()->setValue(browseHistory().currentScrollPos());
   } else {
     // scroll to and select the folder from where we've come up (-> up()).
-    wentUp = false;
+    wentUp_ = false;
     int prevIndex = history_.currentIndex() - 1;
     if (prevIndex >= 0) {
       QModelIndex index = folderView_->indexFromFolderPath(history_.at(prevIndex).path());
@@ -475,7 +474,7 @@ void TabPage::up() {
   if(_path) {
     FmPath* parent = fm_path_get_parent(_path);
     if(parent) {
-      wentUp = true;
+      wentUp_ = true;
       chdir(parent, true);
     }
   }

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -211,6 +211,7 @@ private:
   QString statusText_[StatusTextNum];
   Fm::BrowseHistory history_; // browsing history
   bool overrideCursor_;
+  bool wentUp_;
 };
 
 }


### PR DESCRIPTION
When the user goes up from a folder whose parent contains several other folders too, he/she may need to quickly see from where he has come there. This second commit makes that possible by selecting and scrolling to the child folder.

Nautilus (and Nemo, by inheritance) has had this useful feature for a long time. Dolphin/Konqueror has never had it. It's nice to have it with PCManFM-qt, IMO.

P.S. This comes after #221 (they have common files), so the diff of #221 is also included.