### PR TITLE
Select new files when they are created.

### DIFF
--- a/libfm-qt/foldermodel.cpp
+++ b/libfm-qt/foldermodel.cpp
@@ -103,8 +103,10 @@ void FolderModel::onFilesAdded(FmFolder* folder, GSList* files, gpointer user_da
   FolderModel* model = static_cast<FolderModel*>(user_data);
   int n_files = g_slist_length(files);
   model->beginInsertRows(QModelIndex(), model->items.count(), model->items.count() + n_files - 1);
+  FmFileInfoList* infoList = fm_file_info_list_new();
   for(GSList* l = files; l; l = l->next) {
     FmFileInfo* info = FM_FILE_INFO(l->data);
+    fm_file_info_list_push_tail(infoList, info);
     FolderModelItem item(info);
 /*
     if(fm_file_info_is_hidden(info)) {
@@ -115,6 +117,7 @@ void FolderModel::onFilesAdded(FmFolder* folder, GSList* files, gpointer user_da
     model->items.append(item);
   }
   model->endInsertRows();
+  Q_EMIT model->filesAdded(infoList);
 }
 
 //static
@@ -389,7 +392,10 @@ bool FolderModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int
       info = fileInfoFromIndex(itemIndex);
     }
     if(info)
-      destPath = fm_file_info_get_path(info);
+      if (fm_file_info_is_dir(info))
+        destPath = fm_file_info_get_path(info);
+      else
+        destPath = path();
     else
       return false;
   }

--- a/libfm-qt/foldermodel.h
+++ b/libfm-qt/foldermodel.h
@@ -88,6 +88,7 @@ public:
 
 Q_SIGNALS:
   void thumbnailLoaded(const QModelIndex& index, int size);
+  void filesAdded(FmFileInfoList* infoList);
 
 public Q_SLOTS:
   void updateIcons();

--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -712,6 +712,18 @@ FmPathList* FolderView::selectedFilePaths() const {
   return NULL;
 }
 
+QModelIndex FolderView::indexFromFolderPath(FmPath* folderPath) const {
+  QModelIndex index;
+  int count = model_->rowCount();
+  for(int row = 0; row < count; ++row) {
+    index = model_->index(row, 0);
+    FmFileInfo* info = model_->fileInfoFromIndex(index);
+    if(info && fm_file_info_is_dir(info) && fm_path_equal(folderPath,fm_file_info_get_path(info)))
+      return index;
+  }
+  return QModelIndex();
+}
+
 FmFileInfoList* FolderView::selectedFiles() const {
   if(model_) {
     QModelIndexList selIndexes = mode == DetailedListMode ? selectedRows() : selectedIndexes();

--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -725,7 +725,7 @@ QModelIndex FolderView::indexFromFolderPath(FmPath* folderPath) const {
 }
 
 void FolderView::selectFiles(FmFileInfoList* files) {
-  if (!files) return;
+  if (!model_ || !files) return;
   selectionModel()->clear();
   QModelIndex index, firstIndex;
   int count = model_->rowCount();

--- a/libfm-qt/folderview.h
+++ b/libfm-qt/folderview.h
@@ -95,6 +95,7 @@ public:
   QItemSelectionModel* selectionModel() const;
   FmFileInfoList* selectedFiles() const;
   FmPathList* selectedFilePaths() const;
+  QModelIndex indexFromFolderPath(FmPath* folderPath) const;
 
   void selectAll();
 

--- a/libfm-qt/folderview.h
+++ b/libfm-qt/folderview.h
@@ -96,6 +96,7 @@ public:
   FmFileInfoList* selectedFiles() const;
   FmPathList* selectedFilePaths() const;
   QModelIndex indexFromFolderPath(FmPath* folderPath) const;
+  void selectFiles(FmFileInfoList* files);
 
   void selectAll();
 

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -188,6 +188,8 @@ protected Q_SLOTS:
   void onModelSortFilterChanged();
   void onSelChanged(int numSel);
   void restoreScrollPos();
+  void onFilesAdded(FmFileInfoList* files);
+  void stopWatchingNewFiles();
 
 private:
   void freeFolder();


### PR DESCRIPTION
When files/folders are created (pasted, extracted, etc.) in the currently open folder, this commit selects them and scrolls to the first one. If there's only one file, it'll have focus too.

Structure: A signal containing info on added files (filesAdded) is emitted by FolderModel and connected/disconnected to/from a selecting slot (onFilesAdded) by TabPage appropriately. That slot uses FolderView::selectFiles.

Dolphin does a similar thing. With folders that contain many files, this has two practical benefits, at least:
* The user sees where pasted/extracted/new files go and can find them easily for later work or copy/cut/delete all of them.
* When he creates a new file/folder, he can immediately open it by pressing Enter.

It isn't for Desktop (yet).

P.S. (1) Please ignore the commits of #221 and #222 included by GitHub. (2) Here I also fixed a related issue, namely dropping on file, in contrast to folder (see FolderModel::dropMimeData).