### PR TITLE
Fix (workaround) a crash in placesview.

### DIFF
--- a/libfm-qt/placesview.cpp
+++ b/libfm-qt/placesview.cpp
@@ -105,6 +105,10 @@ void PlacesView::activateRow(int type, const QModelIndex& index) {
 
 // mouse button pressed
 void PlacesView::onPressed(const QModelIndex& index) {
+  /* FIXME: (Tsu Jan) If column 1 is middle clicked by chance, the app
+     will crash because of an "invalid" FmPath. I found no way to check
+     an FmPath for its "validity", hence the following conditional. */
+  if(index.column() > 0) return;
   // if middle button is pressed
   if(QGuiApplication::mouseButtons() & Qt::MiddleButton) {
     activateRow(1, index);


### PR DESCRIPTION
If the second column (column 1, to the right) of an item in Places side-pane is middle clicked accidentally, the app will crash. The cause is that "path" obtained in PlacesView::activateRow on the basis of column 1 will be so "invalid" that no FmPath function could deal with it. Apparently there's no way to check an FmPath for its "validity" but a simple conditional can prevent the crash.