### PR TITLE
Fix (workaround) for right-click crash in placesview.

### DIFF
--- a/libfm-qt/placesview.cpp
+++ b/libfm-qt/placesview.cpp
@@ -322,6 +322,8 @@ void PlacesView::onEjectVolume() {
 void PlacesView::contextMenuEvent(QContextMenuEvent* event) {
   QModelIndex index = indexAt(event->pos());
   if(index.isValid() && index.parent().isValid()) {
+    if(index.column() != 0) // the real item is at column 0
+      index = index.sibling(index.row(), 0);
     QMenu* menu = new QMenu(this);
     QAction* action;
     PlacesModelItem* item = static_cast<PlacesModelItem*>(model_->itemFromIndex(index));


### PR DESCRIPTION
Like what palinek did for the middle-click crash but now for the right-click menu on the second column and then clicking on a menu-item.
The real solution should be somewhere else but these two fixes will suffice for now.