### PR TITLE
Added a filterbar + Handle virtually hidden files

### DIFF
--- a/libfm-qt/proxyfoldermodel.cpp
+++ b/libfm-qt/proxyfoldermodel.cpp
@@ -254,6 +254,10 @@ void ProxyFolderModel::removeFilter(ProxyFolderModelFilter* filter) {
   Q_EMIT sortFilterChanged();
 }
 
+void ProxyFolderModel::updateFilters() {
+  invalidate();
+  Q_EMIT sortFilterChanged();
+}
 
 #if 0
 void ProxyFolderModel::reloadAllThumbnails() {

--- a/libfm-qt/proxyfoldermodel.h
+++ b/libfm-qt/proxyfoldermodel.h
@@ -50,7 +50,7 @@ public:
   virtual void setSourceModel(QAbstractItemModel* model);
 
   void setShowHidden(bool show);
-  bool showHidden() {
+  bool showHidden() const {
     return showHidden_;
   }
 
@@ -81,6 +81,7 @@ public:
 
   void addFilter(ProxyFolderModelFilter* filter);
   void removeFilter(ProxyFolderModelFilter* filter);
+  void updateFilters();
 
 Q_SIGNALS:
   void sortFilterChanged();

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -49,13 +49,35 @@
         </sizepolicy>
        </property>
       </widget>
-      <widget class="QStackedWidget" name="stackedWidget">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      <widget class="QFrame" name="frame">
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
        </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QStackedWidget" name="stackedWidget">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="filterBar">
+          <property name="placeholderText">
+           <string>Filter by string...</string>
+          </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </widget>
     </item>

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -118,6 +118,8 @@ protected Q_SLOTS:
   void onTabBarCurrentChanged(int index);
   void onTabBarTabMoved(int from, int to);
 
+  void onFilterStringChanged(QString str);
+
   void onShortcutPrevTab();
   void onShortcutNextTab();
   void onShortcutJumpToTab();

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -40,6 +40,23 @@ namespace PCManFM {
 class Settings;
 class Launcher;
 
+class ProxyFilter : public Fm::ProxyFolderModelFilter {
+public:
+  bool filterAcceptsRow(const Fm::ProxyFolderModel* model, FmFileInfo* info) const;
+  virtual ~ProxyFilter() {}
+  void setVirtHidden(FmFolder* folder);
+  QString getFilterStr() {
+    return filterStr_;
+  }
+  void setFilterStr(QString str) {
+    filterStr_ = str;
+  }
+
+private:
+  QString filterStr_;
+  QStringList virtHiddenList_;
+};
+
 class TabPage : public QWidget {
 Q_OBJECT
 
@@ -98,9 +115,7 @@ public:
     return proxyModel_->showHidden();
   }
 
-  void setShowHidden(bool showHidden) {
-    proxyModel_->setShowHidden(showHidden);
-  }
+  void setShowHidden(bool showHidden);
 
   FmPath* path() {
     return folder_ ? fm_folder_get_path(folder_) : NULL;
@@ -137,8 +152,10 @@ public:
   void invertSelection();
 
   void reload() {
-    if(folder_)
+    if(folder_) {
+      proxyFilter_->setVirtHidden(folder_); // reread ".hidden"
       fm_folder_reload(folder_);
+    }
   }
 
   QString title() const {
@@ -177,6 +194,19 @@ public:
     return folderView_->fileLauncher();
   }
 
+  QString getFilterStr() {
+    if(proxyFilter_)
+      return proxyFilter_->getFilterStr();
+    return QString();
+  }
+
+  void setFilterStr(QString str) {
+    if(proxyFilter_)
+      proxyFilter_->setFilterStr(str);
+  }
+
+  void applyFilter();
+
 Q_SIGNALS:
   void statusChanged(int type, QString statusText);
   void titleChanged(QString title);
@@ -205,6 +235,7 @@ private:
   View* folderView_;
   Fm::CachedFolderModel* folderModel_;
   Fm::ProxyFolderModel* proxyModel_;
+  ProxyFilter* proxyFilter_;
   QVBoxLayout* verticalLayout;
   FmFolder* folder_;
   QString title_;


### PR DESCRIPTION
This commit consists of two parts that, contrary to appearances, are closely related to each other:

(1) The filterbar is tab-aware but is cleared on changing directory in the same tab. Although it's a fixed part of the GUI, this can be changed later if needed.

(2) Making files "virtually" hidden is a feature that Nemo/Nautilus have and is requested for Dolphin (but ignored by KDE devs) for a long time. The user may want to hide a file without changing or being able to change its name. "lost+found" is a good example.

The commit simply uses the ADT "ProxyFolderModelFilter", which PCMan has included in "proxyfoldermodel.h" for adding extra filters. For virtually hidden files, it reads the file ".hidden" inside the current folder once and hides the listed files from the tabpage but, intentionally, not from the sidepane tree. This exception aside, the virtually hidden files behave like the usual hidden files.

P.S. Because I had applied my commits consecutively for my personal use, I had to "extract" this one manually. Therefore, although I've used this feature for a week, I tested this particular commit only a few times.