### PR TITLE
Add apply button to desktop preferences dialog

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>501</width>
-    <height>376</height>
+    <height>434</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -295,7 +295,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -85,12 +85,16 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   ui.textColor->setColor(settings.desktopFgColor());
   ui.shadowColor->setColor(settings.desktopShadowColor());
   ui.showWmMenu->setChecked(settings.showWmMenu());
+
+  connect(ui.buttonBox->button(QDialogButtonBox::Apply), &QPushButton::clicked,
+          this, &DesktopPreferencesDialog::onApplyClicked);
 }
 
 DesktopPreferencesDialog::~DesktopPreferencesDialog() {
 }
 
-void DesktopPreferencesDialog::accept() {
+void DesktopPreferencesDialog::applySettings()
+{
   Settings& settings = static_cast<Application*>(qApp)->settings();
 
   XdgDir::setDesktopDir(ui.desktopFolder->text());
@@ -104,10 +108,19 @@ void DesktopPreferencesDialog::accept() {
   settings.setDesktopShadowColor(ui.shadowColor->color());
   settings.setShowWmMenu(ui.showWmMenu->isChecked());
 
-  QDialog::accept();
-
-  static_cast<Application*>(qApp)->updateDesktopsFromSettings();
   settings.save();
+}
+
+void DesktopPreferencesDialog::onApplyClicked()
+{
+  applySettings();
+  static_cast<Application*>(qApp)->updateDesktopsFromSettings();
+}
+
+void DesktopPreferencesDialog::accept() {
+  applySettings();
+  static_cast<Application*>(qApp)->updateDesktopsFromSettings();
+  QDialog::accept();
 }
 
 void DesktopPreferencesDialog::onWallpaperModeChanged(int index) {

--- a/pcmanfm/desktoppreferencesdialog.h
+++ b/pcmanfm/desktoppreferencesdialog.h
@@ -38,9 +38,12 @@ public:
   void selectPage(QString name);
 
 protected Q_SLOTS:
+  void onApplyClicked();
   void onWallpaperModeChanged(int index);
   void onBrowseClicked();
   void onBrowseDesktopFolderClicked();
+
+  void applySettings();
 
 private:
   Ui::DesktopPreferencesDialog ui;


### PR DESCRIPTION
That way one does not have to reopen the dialog if he does not like the change.

![screen](https://cloud.githubusercontent.com/assets/1238157/10112540/795e350a-63b2-11e5-8117-07fd710b08b6.png)

Maybe an apply button and an ok button together is not a good idea? LXQt's standard is to apply settings on select and have a reset and a cancel button. With this patch, even if one has already applyed settings, clicking ok to leave the dialog will reapply the settings.

Fixes lxde/lxqt#391.