### PR TITLE
Upgrade of pcmanfm-qt to C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,24 @@ include(LXQtTranslateDesktop)
 
 add_definitions(-DQT_NO_KEYWORDS)
 
+if (CMAKE_VERSION VERSION_LESS "3.1")
+    include(CheckCXXCompilerFlag)
+    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+    if(COMPILER_SUPPORTS_CXX11)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    else()
+        CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+        # -std=c++0x is deprecated but some tools e.g. qmake or older gcc are still using it
+        if(COMPILER_SUPPORTS_CXX0X)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+        else()
+            message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER} does not support c++11/c++0x")
+        endif()
+    endif()
+else()
+  set(CMAKE_CXX_STANDARD 11)
+endif()
+
 if (CMAKE_COMPILER_IS_GNUCXX)
     # set visibility to hidden to hide symbols, unless they're exported manually in the code
     set(CMAKE_CXX_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions ${CMAKE_CXX_FLAGS}")

--- a/libfm-qt/appmenuview_p.h
+++ b/libfm-qt/appmenuview_p.h
@@ -35,7 +35,7 @@ public:
     if(menu_cache_item_get_icon(item))
       fmicon = fm_icon_from_name(menu_cache_item_get_icon(item));
     else
-      fmicon = NULL;
+      fmicon = nullptr;
     setText(QString::fromUtf8(menu_cache_item_get_name(item)));
     setEditable(false);
     setDragEnabled(false);

--- a/libfm-qt/dirtreemodelitem.cpp
+++ b/libfm-qt/dirtreemodelitem.cpp
@@ -26,24 +26,24 @@
 namespace Fm {
 
 DirTreeModelItem::DirTreeModelItem():
-  model_(NULL),
-  folder_(NULL),
+  model_(nullptr),
+  folder_(nullptr),
   expanded_(false),
   loaded_(false),
-  fileInfo_(NULL),
-  placeHolderChild_(NULL),
-  parent_(NULL) {
+  fileInfo_(nullptr),
+  placeHolderChild_(nullptr),
+  parent_(nullptr) {
 }
 
 DirTreeModelItem::DirTreeModelItem(FmFileInfo* info, DirTreeModel* model, DirTreeModelItem* parent):
   model_(model),
-  folder_(NULL),
+  folder_(nullptr),
   expanded_(false),
   loaded_(false),
   fileInfo_(fm_file_info_ref(info)),
   displayName_(QString::fromUtf8(fm_file_info_get_disp_name(info))),
   icon_(IconTheme::icon(fm_file_info_get_icon(info))),
-  placeHolderChild_(NULL),
+  placeHolderChild_(nullptr),
   parent_(parent) {
 
   if(info)
@@ -85,7 +85,7 @@ void DirTreeModelItem::freeFolder() {
     g_signal_handlers_disconnect_by_func(folder_, gpointer(onFolderFilesRemoved), this);
     g_signal_handlers_disconnect_by_func(folder_, gpointer(onFolderFilesChanged), this);
     g_object_unref(folder_);
-    folder_ = NULL;
+    folder_ = nullptr;
   }
 }
 
@@ -216,7 +216,7 @@ qDebug() << "folder loaded";
     _this->children_.removeAt(pos);
     delete _this->placeHolderChild_;
     model->endRemoveRows();
-    _this->placeHolderChild_ = NULL;
+    _this->placeHolderChild_ = nullptr;
   }
 
   Q_EMIT model->rowLoaded(index);
@@ -272,7 +272,7 @@ void DirTreeModelItem::onFolderFilesChanged(FmFolder* folder, GSList* files, gpo
 
 DirTreeModelItem* DirTreeModelItem::childFromName(const char* utf8_name, int* pos) {
   int i = 0;
-  Q_FOREACH(DirTreeModelItem* item, children_) {
+  for (const auto item : children_) {
     if(item->fileInfo_ && strcmp(fm_file_info_get_name(item->fileInfo_), utf8_name) == 0) {
       if(pos)
         *pos = i;
@@ -280,25 +280,24 @@ DirTreeModelItem* DirTreeModelItem::childFromName(const char* utf8_name, int* po
     }
     ++i;
   }
-  return NULL;
+  return nullptr;
 }
 
 DirTreeModelItem* DirTreeModelItem::childFromPath(FmPath* path, bool recursive) const {
-  Q_ASSERT(path != NULL);
+  Q_ASSERT(path != nullptr);
 
   Q_FOREACH(DirTreeModelItem* item, children_) {
     // if(item->fileInfo_)
     //  qDebug() << "child: " << QString::fromUtf8(fm_file_info_get_disp_name(item->fileInfo_));
     if(item->fileInfo_ && fm_path_equal(fm_file_info_get_path(item->fileInfo_), path)) {
       return item;
-    }
-    else if(recursive) {
+    } else if(recursive) {
       DirTreeModelItem* child = item->childFromPath(path, true);
       if(child)
-	return child;
+        return child;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 void DirTreeModelItem::setShowHidden(bool show) {

--- a/libfm-qt/dirtreemodelitem.h
+++ b/libfm-qt/dirtreemodelitem.h
@@ -38,14 +38,14 @@ public:
   friend class DirTreeView; // allow direct access of private members in DirTreeView
 
   explicit DirTreeModelItem();
-  explicit DirTreeModelItem(FmFileInfo* info, DirTreeModel* model, DirTreeModelItem* parent = NULL);
+  explicit DirTreeModelItem(FmFileInfo* info, DirTreeModel* model, DirTreeModelItem* parent = nullptr);
   ~DirTreeModelItem();
 
   void loadFolder();
   void unloadFolder();
 
-  bool isPlaceHolder() {
-    return (fileInfo_ == NULL);
+  inline bool isPlaceHolder() const {
+    return (fileInfo_ == nullptr);
   }
 
   void setShowHidden(bool show);

--- a/libfm-qt/folderitemdelegate.cpp
+++ b/libfm-qt/folderitemdelegate.cpp
@@ -57,7 +57,7 @@ QSize FolderItemDelegate::sizeHint(const QStyleOptionViewItem& option, const QMo
     // FIXME: there're some problems in this size hint calculation.
     Q_ASSERT(gridSize_ != QSize());
     QRectF textRect(0, 0, gridSize_.width() - 4, gridSize_.height() - opt.decorationSize.height() - 4);
-    drawText(NULL, opt, textRect); // passing NULL for painter will calculate the bounding rect only.
+    drawText(nullptr, opt, textRect); // passing nullptr for painter will calculate the bounding rect only.
     int width = qMax((int)textRect.width(), opt.decorationSize.width()) + 4;
     int height = opt.decorationSize.height() + textRect.height() + 4;
     return QSize(width, height);
@@ -65,18 +65,12 @@ QSize FolderItemDelegate::sizeHint(const QStyleOptionViewItem& option, const QMo
   return QStyledItemDelegate::sizeHint(option, index);
 }
 
-QIcon::Mode FolderItemDelegate::iconModeFromState(QStyle::State state) {
-  QIcon::Mode iconMode;
-  if(state & QStyle::State_Enabled) {
-    if(state & QStyle::State_Selected)
-      iconMode = QIcon::Selected;
-    else {
-      iconMode = QIcon::Normal;
-    }
-  }
-  else
-    iconMode = QIcon::Disabled;
-  return iconMode;
+QIcon::Mode FolderItemDelegate::iconModeFromState(const QStyle::State state) {
+
+  if(state & QStyle::State_Enabled)
+    return (state & QStyle::State_Selected) ? QIcon::Selected : QIcon::Normal;
+
+  return QIcon::Disabled;
 }
 
 // special thanks to Razor-qt developer Alec Moskvin(amoskvin) for providing the fix!
@@ -128,7 +122,7 @@ void FolderItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& op
   }
 }
 
-// if painter is NULL, the method calculate the bounding rectangle of the text and save it to textRect
+// if painter is nullptr, the method calculate the bounding rectangle of the text and save it to textRect
 void FolderItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& opt, QRectF& textRect) const {
   QTextLayout layout(opt.text, opt.font);
   QTextOption textOption;

--- a/libfm-qt/folderitemdelegate.h
+++ b/libfm-qt/folderitemdelegate.h
@@ -30,14 +30,14 @@ namespace Fm {
 class LIBFM_QT_API FolderItemDelegate : public QStyledItemDelegate {
   Q_OBJECT
 public:
-  explicit FolderItemDelegate(QAbstractItemView* view, QObject* parent = 0);
+  explicit FolderItemDelegate(QAbstractItemView* view, QObject* parent = nullptr);
   virtual ~FolderItemDelegate();
 
-  void setGridSize(QSize size) {
+  inline void setGridSize(QSize size) {
     gridSize_ = size;
   }
 
-  QSize gridSize() {
+  inline QSize gridSize() const {
     return gridSize_;
   }
 

--- a/libfm-qt/foldermodel.cpp
+++ b/libfm-qt/foldermodel.cpp
@@ -35,7 +35,7 @@
 using namespace Fm;
 
 FolderModel::FolderModel() :
-  folder_(NULL) {
+  folder_(nullptr) {
 /*
     ColumnIcon,
     ColumnName,
@@ -53,7 +53,7 @@ FolderModel::~FolderModel() {
   qDebug("delete FolderModel");
 
   if(folder_)
-    setFolder(NULL);
+    setFolder(nullptr);
 
   // if the thumbnail requests list is not empty, cancel them
   if(!thumbnailResults.empty()) {
@@ -85,7 +85,7 @@ void FolderModel::setFolder(FmFolder* new_folder) {
       insertFiles(0, fm_folder_get_files(folder_));
   }
   else
-    folder_ = NULL;
+    folder_ = nullptr;
 }
 
 void FolderModel::onStartLoading(FmFolder* folder, gpointer user_data) {
@@ -188,10 +188,10 @@ FolderModelItem* FolderModel::itemFromIndex(const QModelIndex& index) const {
 
 FmFileInfo* FolderModel::fileInfoFromIndex(const QModelIndex& index) const {
   FolderModelItem* item = itemFromIndex(index);
-  return item ? item->info : NULL;
+  return item ? item->info : nullptr;
 }
 
-QVariant FolderModel::data(const QModelIndex & index, int role = Qt::DisplayRole) const {
+QVariant FolderModel::data(const QModelIndex & index, int role/* = Qt::DisplayRole*/) const {
   if(!index.isValid() || index.row() > items.size() || index.column() >= NumOfColumns) {
     return QVariant();
   }
@@ -239,7 +239,7 @@ QVariant FolderModel::data(const QModelIndex & index, int role = Qt::DisplayRole
   return QVariant();
 }
 
-QVariant FolderModel::headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const {
+QVariant FolderModel::headerData(int section, Qt::Orientation orientation, int role/* = Qt::DisplayRole*/) const {
   if(role == Qt::DisplayRole) {
     if(orientation == Qt::Horizontal) {
       QString title;
@@ -358,9 +358,7 @@ QMimeData* FolderModel::mimeData(const QModelIndexList& indexes) const {
   QByteArray urilist;
   urilist.reserve(4096);
 
-  QModelIndexList::const_iterator it;
-  for(it = indexes.constBegin(); it != indexes.end(); ++it) {
-    const QModelIndex index = *it;
+  for(const auto &index : indexes) {
     FolderModelItem* item = itemFromIndex(index);
     if(item) {
       FmPath* path = fm_file_info_get_path(item->info);
@@ -429,17 +427,15 @@ Qt::DropActions FolderModel::supportedDropActions() const {
 }
 
 // ask the model to load thumbnails of the specified size
-void FolderModel::cacheThumbnails(int size) {
-  QVector<QPair<int, int> >::iterator it;
-  for(it = thumbnailRefCounts.begin(); it != thumbnailRefCounts.end(); ++it) {
-    if(it->first == size) {
-      break;
-    }
+void FolderModel::cacheThumbnails(const int size) {
+  QVector<QPair<int, int>>::iterator it = thumbnailRefCounts.begin();
+  while (it != thumbnailRefCounts.end()) {
+    if (it->first == size) {
+      ++it->second;
+      return;
+    } else ++it;
   }
-  if(it != thumbnailRefCounts.end())
-    ++it->second;
-  else
-    thumbnailRefCounts.append(QPair<int, int>(size, 1));
+  thumbnailRefCounts.append(QPair<int, int>(size, 1));
 }
 
 // ask the model to free cached thumbnails of the specified size
@@ -541,8 +537,7 @@ QImage FolderModel::thumbnailFromIndex(const QModelIndex& index, int size) {
       }
       case FolderModelItem::ThumbnailLoaded:
         return thumbnail->image;
-      default:
-        break;
+      default:;
     }
   }
   return QImage();

--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -41,7 +41,7 @@
 
 Q_DECLARE_OPAQUE_POINTER(FmFileInfo*)
 
-namespace Fm {
+using namespace Fm;
 
 FolderViewListView::FolderViewListView(QWidget* parent):
   QListView(parent),
@@ -76,7 +76,7 @@ QModelIndex FolderViewListView::indexAt(const QPoint& point) const {
   if(viewMode() == QListView::IconMode && index.isValid()) {
     // FIXME: this hack only improves the usability partially. We still need more precise sizeHint handling.
     // FolderItemDelegate* delegate = static_cast<FolderItemDelegate*>(itemDelegateForColumn(FolderModel::ColumnFileName));
-    // Q_ASSERT(delegate != NULL);
+    // Q_ASSERT(delegate != nullptr);
     // We use the grid size - (2, 2) as the size of the bounding rectangle of the whole item.
     // The width of the text label hence is gridSize.width - 2, and the width and height of the icon is from iconSize().
     QRect visRect = visualRect(index); // visibal area on the screen
@@ -147,7 +147,7 @@ void FolderViewListView::dropEvent(QDropEvent* e) {
 
 void FolderViewListView::mouseReleaseEvent(QMouseEvent* event) {
   bool activationWasAllowed = activationAllowed_;
-  if ((!style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick, NULL, this)) || (event->button() != Qt::LeftButton)) {
+  if ((!style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick, nullptr, this)) || (event->button() != Qt::LeftButton)) {
     activationAllowed_ = false;
   }
 
@@ -158,7 +158,7 @@ void FolderViewListView::mouseReleaseEvent(QMouseEvent* event) {
 
 void FolderViewListView::mouseDoubleClickEvent(QMouseEvent* event) {
   bool activationWasAllowed = activationAllowed_;
-  if ((style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick, NULL, this)) || (event->button() != Qt::LeftButton)) {
+  if ((style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick, nullptr, this)) || (event->button() != Qt::LeftButton)) {
     activationAllowed_ = false;
   }
 
@@ -177,7 +177,7 @@ void FolderViewListView::activation(const QModelIndex &index) {
 
 FolderViewTreeView::FolderViewTreeView(QWidget* parent):
   QTreeView(parent),
-  layoutTimer_(NULL),
+  layoutTimer_(nullptr),
   doingLayout_(false),
   activationAllowed_(true) {
 
@@ -286,7 +286,7 @@ void FolderViewTreeView::layoutColumns() {
 
   if(layoutTimer_) {
     delete layoutTimer_;
-    layoutTimer_ = NULL;
+    layoutTimer_ = nullptr;
   }
 }
 
@@ -342,7 +342,7 @@ void FolderViewTreeView::queueLayoutColumns() {
 
 void FolderViewTreeView::mouseReleaseEvent(QMouseEvent* event) {
   bool activationWasAllowed = activationAllowed_;
-  if ((!style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick, NULL, this)) || (event->button() != Qt::LeftButton)) {
+  if ((!style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick, nullptr, this)) || (event->button() != Qt::LeftButton)) {
     activationAllowed_ = false;
   }
 
@@ -353,7 +353,7 @@ void FolderViewTreeView::mouseReleaseEvent(QMouseEvent* event) {
 
 void FolderViewTreeView::mouseDoubleClickEvent(QMouseEvent* event) {
   bool activationWasAllowed = activationAllowed_;
-  if ((style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick, NULL, this)) || (event->button() != Qt::LeftButton)) {
+  if ((style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick, nullptr, this)) || (event->button() != Qt::LeftButton)) {
     activationAllowed_ = false;
   }
 
@@ -383,13 +383,13 @@ void FolderViewTreeView::onSortFilterChanged() {
 
 FolderView::FolderView(ViewMode _mode, QWidget* parent):
   QWidget(parent),
-  view(NULL),
+  view(nullptr),
   mode((ViewMode)0),
   autoSelectionDelay_(600),
-  autoSelectionTimer_(NULL),
-  selChangedTimer_(NULL),
-  fileLauncher_(NULL),
-  model_(NULL) {
+  autoSelectionTimer_(nullptr),
+  selChangedTimer_(nullptr),
+  fileLauncher_(nullptr),
+  model_(nullptr) {
 
   iconSize_[IconMode - FirstViewMode] = QSize(48, 48);
   iconSize_[CompactMode - FirstViewMode] = QSize(24, 24);
@@ -423,7 +423,7 @@ void FolderView::onItemActivated(QModelIndex index) {
 
 void FolderView::onSelChangedTimeout() {
   selChangedTimer_->deleteLater();
-  selChangedTimer_ = NULL;
+  selChangedTimer_ = nullptr;
 
   QItemSelectionModel* selModel = selectionModel();
   int nSel = 0;
@@ -459,7 +459,7 @@ void FolderView::setViewMode(ViewMode _mode) {
   bool recreateView = false;
   if(view && (mode == DetailedListMode || _mode == DetailedListMode)) {
     delete view; // FIXME: no virtual dtor?
-    view = NULL;
+    view = nullptr;
     recreateView = true;
   }
   mode = _mode;
@@ -671,7 +671,7 @@ void FolderView::emitClickedAt(ClickType type, const QPoint& pos) {
     if(type == ContextMenuClick) {
       // clear current selection if clicked outside selected files
       view->clearSelection();
-      Q_EMIT clicked(type, NULL);
+      Q_EMIT clicked(type, nullptr);
     }
   }
 }
@@ -694,7 +694,7 @@ QModelIndexList FolderView::selectedIndexes() const {
 }
 
 QItemSelectionModel* FolderView::selectionModel() const {
-  return view ? view->selectionModel() : NULL;
+  return view ? view->selectionModel() : nullptr;
 }
 
 FmPathList* FolderView::selectedFilePaths() const {
@@ -710,7 +710,7 @@ FmPathList* FolderView::selectedFilePaths() const {
       return paths;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 FmFileInfoList* FolderView::selectedFiles() const {
@@ -726,7 +726,7 @@ FmFileInfoList* FolderView::selectedFiles() const {
       return files;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 void FolderView::selectAll() {
@@ -916,19 +916,19 @@ void FolderView::onAutoSelectionTimeout() {
   }
 
   autoSelectionTimer_->deleteLater();
-  autoSelectionTimer_ = NULL;
+  autoSelectionTimer_ = nullptr;
 }
 
 void FolderView::onFileClicked(int type, FmFileInfo* fileInfo) {
   if(type == ActivatedClick) {
     if(fileLauncher_) {
-      GList* files = g_list_append(NULL, fileInfo);
-      fileLauncher_->launchFiles(NULL, files);
+      GList* files = g_list_append(nullptr, fileInfo);
+      fileLauncher_->launchFiles(nullptr, files);
       g_list_free(files);
     }
   }
   else if(type == ContextMenuClick) {
-    FmPath* folderPath = NULL;
+    FmPath* folderPath = nullptr;
     FmFileInfoList* files = selectedFiles();
     if (files) {
       FmFileInfo* first = fm_file_info_list_peek_head(files);
@@ -937,7 +937,7 @@ void FolderView::onFileClicked(int type, FmFileInfo* fileInfo) {
     }
     if (!folderPath)
       folderPath = path();
-    QMenu* menu = NULL;
+    QMenu* menu = nullptr;
     if(fileInfo) {
       // show context menu
       if (FmFileInfoList* files = selectedFiles()) {
@@ -966,5 +966,3 @@ void FolderView::prepareFileMenu(FileMenu* menu) {
 void FolderView::prepareFolderMenu(FolderMenu* menu) {
 }
 
-
-} // namespace Fm

--- a/libfm-qt/folderview.h
+++ b/libfm-qt/folderview.h
@@ -43,6 +43,7 @@ class LIBFM_QT_API FolderView : public QWidget {
   Q_OBJECT
 
 public:
+
   enum ViewMode {
     FirstViewMode = 1,
     IconMode = FirstViewMode,
@@ -58,8 +59,6 @@ public:
     MiddleClick,
     ContextMenuClick
   };
-
-public:
 
   friend class FolderViewTreeView;
   friend class FolderViewListView;

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -69,7 +69,7 @@ public:
   };
 
 public:
-  explicit TabPage(FmPath* path, QWidget* parent = 0);
+  explicit TabPage(FmPath* path, QWidget* parent = nullptr);
   virtual ~TabPage();
 
   void chdir(FmPath* newPath, bool addHistory = true);
@@ -118,7 +118,7 @@ public:
   void setShowHidden(bool showHidden);
 
   FmPath* path() {
-    return folder_ ? fm_folder_get_path(folder_) : NULL;
+    return folder_ ? fm_folder_get_path(folder_) : nullptr;
   }
 
   QString pathName();


### PR DESCRIPTION
    Use ‘nullptr’ instead of ‘NULL’

        Safer and semantically more correct,
      	    in C: #define NULL ((void *)0)
            in C++ < C++11: #define NULL 0

    Use of C++11 features when it improved readability/legibility

    Minor optimizations