### PR TITLE
Tab context menu for closing other tabs

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -721,6 +721,27 @@
     <string>Filter</string>
    </property>
   </action>
+  <action name="actionCloseLeft">
+   <property name="icon">
+    <iconset theme="go-previous"/>
+   </property>
+   <property name="text">
+    <string>Close &amp;left tabs</string>
+   </property>
+  </action>
+  <action name="actionCloseRight">
+   <property name="icon">
+    <iconset theme="go-next"/>
+   </property>
+   <property name="text">
+    <string>Close &amp;right tabs</string>
+   </property>
+  </action>
+  <action name="actionCloseOther">
+   <property name="text">
+    <string>Close &amp;other tabs</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -143,6 +143,14 @@ protected Q_SLOTS:
 
   void onBackForwardContextMenu(QPoint pos);
 
+  void tabContextMenu(const QPoint& pos);
+  void closeLeftTabs();
+  void closeRightTabs();
+  void closeOtherTabs() {
+    closeLeftTabs();
+    closeRightTabs();
+  }
+
 protected:
   // void changeEvent( QEvent * event);
   void closeTab(int index);
@@ -162,6 +170,7 @@ private:
   QLabel* fsInfoLabel;
   FmBookmarks* bookmarks;
   Launcher fileLauncher_;
+  int rightClickIndex;
 };
 
 }


### PR DESCRIPTION
This is a right-click menu, only for tabs and only when there is more than one tab, for closing the left, right or other tabs, depending on the the right clicked tab, which can be the current one or not. It comes in handy when there are several tabs.