### PR TITLE
Fix compiling with Qt < 5.4

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -338,7 +338,7 @@ void Application::onUserDirsChanged()
       }
     } else {
         qWarning("Application::onUserDirsChanged: %s doesn't exist",
-                    qUtf8Printable(userDesktopFolder_));
+                    userDesktopFolder_.toUtf8().constData());
     }
   }
 }


### PR DESCRIPTION
The global qUtf8Printable() is not available in versions before Qt 5.4.

Thanks!
