### PR TITLE
Fixed several problems with item selection and alignment

### DIFF
--- a/libfm-qt/folderitemdelegate.cpp
+++ b/libfm-qt/folderitemdelegate.cpp
@@ -54,12 +54,11 @@ QSize FolderItemDelegate::sizeHint(const QStyleOptionViewItem& option, const QMo
     opt.decorationAlignment = Qt::AlignHCenter|Qt::AlignTop;
     opt.displayAlignment = Qt::AlignTop|Qt::AlignHCenter;
 
-    // FIXME: there're some problems in this size hint calculation.
     Q_ASSERT(gridSize_ != QSize());
-    QRectF textRect(0, 0, gridSize_.width() - 4, gridSize_.height() - opt.decorationSize.height() - 4);
+    QRectF textRect(0, 0, gridSize_.width(), gridSize_.height() - opt.decorationSize.height());
     drawText(NULL, opt, textRect); // passing NULL for painter will calculate the bounding rect only.
-    int width = qMax((int)textRect.width(), opt.decorationSize.width()) + 4;
-    int height = opt.decorationSize.height() + textRect.height() + 4;
+    int width = qMax((int)textRect.width(), opt.decorationSize.width());
+    int height = opt.decorationSize.height() + textRect.height();
     return QSize(width, height);
   }
   return QStyledItemDelegate::sizeHint(option, index);
@@ -107,7 +106,11 @@ void FolderItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& op
       painter->drawPixmap(iconPos, symlinkIcon_.pixmap(opt.decorationSize / 2, iconMode));
 
     // draw the text
-    QRectF textRect(opt.rect.x(), opt.rect.y() + opt.decorationSize.height(), opt.rect.width(), opt.rect.height() - opt.decorationSize.height());
+    // The text rect dimensions should be exactly as they were in sizeHint()
+    QRectF textRect(opt.rect.x() - (gridSize_.width() - opt.rect.width()) / 2,
+                    opt.rect.y() + opt.decorationSize.height(),
+                    gridSize_.width(),
+                    gridSize_.height() - opt.decorationSize.height());
     drawText(painter, opt, textRect);
     painter->restore();
   }
@@ -141,6 +144,7 @@ void FolderItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& opt
   int visibleLines = 0;
   layout.beginLayout();
   QString elidedText;
+  textRect.adjust(2, 2, -2, -2); // a 2-px margin is considered at FolderView::updateGridSize()
   for(;;) {
     QTextLine line = layout.createLine();
     if(!line.isValid())
@@ -162,21 +166,25 @@ void FolderItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& opt
     ++ visibleLines;
   }
   layout.endLayout();
+  width = qMax(width, (qreal)opt.fontMetrics.width(elidedText));
 
   // draw background for selected item
   QRectF boundRect = layout.boundingRect();
   //qDebug() << "bound rect: " << boundRect << "width: " << width;
   boundRect.setWidth(width);
+  boundRect.setHeight(height);
   boundRect.moveTo(textRect.x() + (textRect.width() - width)/2, textRect.y());
 
+  QRectF selRect = boundRect.adjusted(-2, -2, 2, 2);
+
   if(!painter) { // no painter, calculate the bounding rect only
-    textRect = boundRect;
+    textRect = selRect;
     return;
   }
 
   QPalette::ColorGroup cg = opt.state & QStyle::State_Enabled ? QPalette::Normal : QPalette::Disabled;
   if(opt.state & QStyle::State_Selected) {
-    painter->fillRect(boundRect, opt.palette.highlight());
+    painter->fillRect(selRect, opt.palette.highlight());
     painter->setPen(opt.palette.color(cg, QPalette::HighlightedText));
   }
   else
@@ -186,7 +194,7 @@ void FolderItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& opt
   for(int i = 0; i < visibleLines; ++i) {
     QTextLine line = layout.lineAt(i);
     if(i == (visibleLines - 1) && !elidedText.isEmpty()) { // the last line, draw elided text
-      QPointF pos(textRect.x() + line.position().x(), textRect.y() + line.y() + line.ascent());
+      QPointF pos(boundRect.x() + line.position().x(), boundRect.y() + line.y() + line.ascent());
       painter->drawText(pos, elidedText);
     }
     else {
@@ -198,7 +206,7 @@ void FolderItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& opt
     // draw focus rect
     QStyleOptionFocusRect o;
     o.QStyleOption::operator=(opt);
-    o.rect = boundRect.toRect(); // subElementRect(SE_ItemViewItemFocusRect, vopt, widget);
+    o.rect = selRect.toRect(); // subElementRect(SE_ItemViewItemFocusRect, vopt, widget);
     o.state |= QStyle::State_KeyboardFocusChange;
     o.state |= QStyle::State_Item;
     QPalette::ColorGroup cg = (opt.state & QStyle::State_Enabled)

--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -567,16 +567,19 @@ void FolderView::updateGridSize() {
       // each char actually takes doubled space. To be safe, we use 13 chars per line x average char width
       // to get a nearly optimal width for the text label. As most of the filenames have less than 40 chars
       // 13 chars x 3 lines should be enough to show the full filenames for most files.
-      int textWidth = fm.averageCharWidth() * 12 + 4; // add 2 px padding for left and right border
-      int textHeight = fm.height() * 3 + 4; // add 2 px padding for top and bottom border
-      grid.setWidth(qMax(icon.width(), textWidth) + 8); // add a margin 4 px for every cell
-      grid.setHeight(icon.height() + textHeight + 8); // add a margin 4 px for every cell
+      int textWidth = fm.averageCharWidth() * 13;
+      int textHeight = fm.lineSpacing() * 3;
+      grid.setWidth(qMax(icon.width(), textWidth) + 4); // a margin of 2 px for selection rects
+      grid.setHeight(icon.height() + textHeight + 4); // a margin of 2 px for selection rects
       break;
     }
     default:
       ; // do not use grid size
   }
-  listView->setGridSize(grid);
+  if(mode == IconMode || mode == ThumbnailMode)
+    listView->setGridSize(grid + QSize(6, 6)); // a margin of 6 px for every cell
+  else
+    listView->setGridSize(grid);
   FolderItemDelegate* delegate = static_cast<FolderItemDelegate*>(listView->itemDelegateForColumn(FolderModel::ColumnFileName));
   delegate->setGridSize(grid);
 }

--- a/libfm-qt/folderview_p.h
+++ b/libfm-qt/folderview_p.h
@@ -56,6 +56,10 @@ public:
     return QListView::rectForIndex(index);
   }
 
+  inline QStyleOptionViewItem getViewOptions() {
+    return viewOptions();
+  }
+
 Q_SIGNALS:
   void activatedFiltered(const QModelIndex &index);
 

--- a/pcmanfm/desktopitemdelegate.cpp
+++ b/pcmanfm/desktopitemdelegate.cpp
@@ -74,7 +74,20 @@ void DesktopItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
   }
 
   // draw text
-  QRectF textRect(opt.rect.x(), opt.rect.y() + opt.decorationSize.height(), opt.rect.width(), opt.rect.height() - opt.decorationSize.height());
+  QSize gridSize = view_->gridSize() - QSize(6, 6);
+  QRectF textRect(opt.rect.x() - (gridSize.width() - opt.rect.width()) / 2,
+                  opt.rect.y() + opt.decorationSize.height(),
+                  gridSize.width(),
+                  gridSize.height() - opt.decorationSize.height());
+  drawText(painter, opt, textRect);
+
+  if(opt.state & QStyle::State_HasFocus) {
+    // FIXME: draw focus rect
+  }
+  painter->restore();
+}
+
+void DesktopItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& opt, QRectF& textRect) const {
   QTextLayout layout(opt.text, opt.font);
 
   QTextOption textOption;
@@ -87,7 +100,7 @@ void DesktopItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
   int visibleLines = 0;
   layout.beginLayout();
   QString elidedText;
-
+  textRect.adjust(2, 2, -2, -2); // a 2-px margin is considered at FolderView::updateGridSize()
   for(;;) {
     QTextLine line = layout.createLine();
     if(!line.isValid())
@@ -107,13 +120,23 @@ void DesktopItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
     ++ visibleLines;
   }
   layout.endLayout();
+  width = qMax(width, (qreal)opt.fontMetrics.width(elidedText));
   QRectF boundRect = layout.boundingRect();
   boundRect.setWidth(width);
+  boundRect.setHeight(height);
   boundRect.moveTo(textRect.x() + (textRect.width() - width)/2, textRect.y());
+
+  QRectF selRect = boundRect.adjusted(-2, -2, 2, 2);
+
+  if(!painter) { // no painter, calculate the bounding rect only
+    textRect = selRect;
+    return;
+  }
+
   if((opt.state & QStyle::State_Selected) && opt.widget) {
     QPalette palette = opt.widget->palette();
     // qDebug("w: %f, h:%f, m:%f", boundRect.width(), boundRect.height(), layout.minimumWidth());
-    painter->fillRect(boundRect, palette.highlight());
+    painter->fillRect(selRect, palette.highlight());
   }
   else { // only draw shadow for non-selected items
     // draw shadow, FIXME: is it possible to use QGraphicsDropShadowEffect here?
@@ -122,7 +145,7 @@ void DesktopItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
     for(int i = 0; i < visibleLines; ++i) {
       QTextLine line = layout.lineAt(i);
       if(i == (visibleLines - 1) && !elidedText.isEmpty()) { // the last line, draw elided text
-        QPointF pos(textRect.x() + line.position().x() + 1, textRect.y() + line.y() + line.ascent() + 1);
+        QPointF pos(boundRect.x() + line.position().x() + 1, boundRect.y() + line.y() + line.ascent() + 1);
         painter->drawText(pos, elidedText);
       }
       else {
@@ -136,18 +159,13 @@ void DesktopItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
   for(int i = 0; i < visibleLines; ++i) {
     QTextLine line = layout.lineAt(i);
     if(i == (visibleLines - 1) && !elidedText.isEmpty()) { // the last line, draw elided text
-      QPointF pos(textRect.x() + line.position().x(), textRect.y() + line.y() + line.ascent());
+      QPointF pos(boundRect.x() + line.position().x(), boundRect.y() + line.y() + line.ascent());
       painter->drawText(pos, elidedText);
     }
     else {
       line.draw(painter, textRect.topLeft());
     }
   }
-
-  if(opt.state & QStyle::State_HasFocus) {
-    // FIXME: draw focus rect
-  }
-  painter->restore();
 }
 
 QSize DesktopItemDelegate::sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const {
@@ -156,10 +174,17 @@ QSize DesktopItemDelegate::sizeHint(const QStyleOptionViewItem& option, const QM
     return qvariant_cast<QSize>(value);
   QStyleOptionViewItemV4 opt = option;
   initStyleOption(&opt, index);
+  opt.decorationAlignment = Qt::AlignHCenter|Qt::AlignTop;
+  opt.displayAlignment = Qt::AlignTop|Qt::AlignHCenter;
 
-  // use grid size as size hint
-  QSize gridSize = view_->gridSize();
-  return QSize(gridSize.width() -2, gridSize.height() - 2);
+  QSize gridSize = view_->gridSize()
+                   - QSize(6, 6); // a 6-px margin is added at FolderView::updateGridSize()
+  Q_ASSERT(gridSize != QSize());
+  QRectF textRect(0, 0, gridSize.width(), gridSize.height() - opt.decorationSize.height());
+  drawText(NULL, opt, textRect); // passing NULL for painter will calculate the bounding rect only.
+  int width = qMax((int)textRect.width(), opt.decorationSize.width());
+  int height = opt.decorationSize.height() + textRect.height();
+  return QSize(width, height);
 }
 
 DesktopItemDelegate::~DesktopItemDelegate() {

--- a/pcmanfm/desktopitemdelegate.h
+++ b/pcmanfm/desktopitemdelegate.h
@@ -47,6 +47,9 @@ public:
   }
 
 private:
+  void drawText(QPainter* painter, QStyleOptionViewItemV4& opt, QRectF& textRect) const;
+
+private:
   QListView* view_;
   QIcon symlinkIcon_;
   QColor shadowColor_;


### PR DESCRIPTION
Fixes lxde/lxqt#768 (or lxde/pcmanfm-qt#251). In FolderItemDelegate::drawText(), the height of the returned rect shouldn't be that of the created layout because an extra line is added to the latter for calculating the height -- a line that won't be drawn. In fact, a maximum of 3 lines is planned in FolderView::updateGridSize(), while pcmanfm-qt showed 4 lines.