### PR TITLE
Fix --version option not displaying version

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -80,6 +80,8 @@ Application::Application(int& argc, char** argv):
   argc_ = argc;
   argv_ = argv;
 
+  setApplicationVersion(PCMANFM_QT_VERSION);
+
   // QDBusConnection::sessionBus().registerObject("/org/pcmanfm/Application", this);
   QDBusConnection dbus = QDBusConnection::sessionBus();
   if(dbus.registerService(serviceName)) {


### PR DESCRIPTION
No application version string was set for QCommandLineParser to display. It therefore displayed "pcmanfm-qt " [sic] instead of "pcmanfm-qt 0.10.0".

Thanks!
