### PR TITLE
Add bindings to Ctrl+PgUp/Ctrl+PgDn.

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -171,6 +171,15 @@ MainWindow::MainWindow(FmPath* path):
   shortcut = new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab, this);
   connect(shortcut, &QShortcut::activated, this, &MainWindow::onShortcutPrevTab);
 
+  // Add Ctrl+PgUp and Ctrl+PgDown as well, because they are common in Firefox
+  // , Opera, Google Chromium/Google Chrome and most other tab-using
+  // applications.
+  shortcut = new QShortcut(Qt::CTRL + Qt::Key_PageDown, this);
+  connect(shortcut, &QShortcut::activated, this, &MainWindow::onShortcutNextTab);
+
+  shortcut = new QShortcut(Qt::CTRL + Qt::Key_PageUp, this);
+  connect(shortcut, &QShortcut::activated, this, &MainWindow::onShortcutPrevTab);
+
   int i;
   for(i = 0; i < 10; ++i) {
     shortcut = new QShortcut(QKeySequence(Qt::ALT + Qt::Key_0 + i), this);


### PR DESCRIPTION
To switch to next/prev tab as is the general convention.

I hereby disclaim any implicit or explicit ownership of my changes, and
place them under CC0/Public Domain/X11L/Any other licence of your
choice.

I noticed there's quite a lot of duplicate code in creating and binding
shortcuts. Perhaps extracting a small inline method to do that will be a
good idea. What do you say?