### PR TITLE
Fix referencing generated headers in translations

### DIFF
--- a/pcmanfm/CMakeLists.txt
+++ b/pcmanfm/CMakeLists.txt
@@ -37,7 +37,7 @@ qt5_wrap_ui(pcmanfm_UIS_H ${pcmanfm_UIS})
 # add translation for pcmanfm-qt
 lxqt_translate_ts(QM_FILES
     UPDATE_TRANSLATIONS ${UPDATE_TRANSLATIONS}
-    SOURCES ${pcmanfm_SRCS} ${pcmanfm_UIS_H}
+    SOURCES ${pcmanfm_SRCS} ${pcmanfm_UIS}
 )
 
 # translate desktop entry files for pcmanfm-qt and desktop preferences


### PR DESCRIPTION
The translation files referenced the header files generated for the *.ui files during build instead of directly referencing the *.ui files. This made translating with Linguist more difficult because no form previews were displayed. It was fixed by adapting the CMake file to update the translation files directly from *.ui files instead from generated files.

This maybe also fixes the problem with missing previews mentioned in #266 and #270.

Thanks!
