### PR TITLE
hide 'Create New...' menu for files

### DIFF
--- a/pcmanfm/view.cpp
+++ b/pcmanfm/view.cpp
@@ -119,6 +119,7 @@ void View::prepareFileMenu(Fm::FileMenu* menu) {
   }
   else {
     menu->pasteAction()->setVisible(false);
+    menu->createAction()->setVisible(false);
   }
 }
 


### PR DESCRIPTION
Hide the last (?) action remaining for files context menu.

closes #273 ?

PS: requires the pull request of libfm-qt to be accept too...