### PR TITLE
Fix --show-pref option not switching to next name

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -518,7 +518,7 @@ void Application::preferences(QString page) {
     preferencesDialog_ = new PreferencesDialog(page);
   }
   else {
-    // TODO: set page
+    preferencesDialog_.data()->selectPage(page);
   }
   preferencesDialog_.data()->show();
   preferencesDialog_.data()->raise();

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -45,13 +45,7 @@ PreferencesDialog::PreferencesDialog (QString activePage, QWidget* parent):
 
   initFromSettings();
 
-  if(!activePage.isEmpty()) {
-    QWidget* page = findChild<QWidget*>(activePage + "Page");
-    if(page) {
-      int index = ui.stackedWidget->indexOf(page);
-      ui.listWidget->setCurrentRow(index);
-    }
-  }
+  selectPage(activePage);
   adjustSize();
 }
 
@@ -360,6 +354,16 @@ void PreferencesDialog::applySettings() {
 void PreferencesDialog::accept() {
   applySettings();
   QDialog::accept();
+}
+
+void PreferencesDialog::selectPage(QString name) {
+  if(!name.isEmpty()) {
+    QWidget* page = findChild<QWidget*>(name + "Page");
+    if(page) {
+      int index = ui.stackedWidget->indexOf(page);
+      ui.listWidget->setCurrentRow(index);
+    }
+  }
 }
 
 } // namespace PCManFM

--- a/pcmanfm/preferencesdialog.h
+++ b/pcmanfm/preferencesdialog.h
@@ -40,6 +40,8 @@ public:
 
   virtual void accept();
 
+  void selectPage(QString name);
+
 private:
   void initIconThemes(Settings& settings);
   void initArchivers(Settings& settings);


### PR DESCRIPTION
Specifying different page names with --show-pref had no effect if the preferences dialog was as already open. The reason was that selection for an already open dialog was documented but not implemented yet.

Thanks!
