### PR TITLE
Fix --wallpaper-mode description in translations

### DIFF
--- a/pcmanfm/translations/pcmanfm-qt_el.ts
+++ b/pcmanfm/translations/pcmanfm-qt_el.ts
@@ -910,7 +910,7 @@ USA.</translation>
     <message>
         <location filename="../application.cpp" line="190"/>
         <source>Set mode of desktop wallpaper. MODE=(color|stretch|fit|center|tile)</source>
-        <translation>Ορισμός της λειτουργίας της επιφάνειας ΛΕΙΤΟΥΡΓΙΑ=(χρώμα|τέντωμα|προσαρμογή|κέντρο|παράθεση)</translation>
+        <translation>Ορισμός της λειτουργίας της επιφάνειας ΛΕΙΤΟΥΡΓΙΑ=(color|stretch|fit|center|tile)</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="190"/>

--- a/pcmanfm/translations/pcmanfm-qt_es.ts
+++ b/pcmanfm/translations/pcmanfm-qt_es.ts
@@ -888,7 +888,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.</
     <message>
         <location filename="../application.cpp" line="190"/>
         <source>Set mode of desktop wallpaper. MODE=(color|stretch|fit|center|tile)</source>
-        <translation>Definir modo de papel tapiz. MODO =(color|estirar|ajustar|centrar|repetir)</translation>
+        <translation>Definir modo de papel tapiz. MODO =(color|stretch|fit|center|tile)</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="190"/>

--- a/pcmanfm/translations/pcmanfm-qt_fr.ts
+++ b/pcmanfm/translations/pcmanfm-qt_fr.ts
@@ -795,7 +795,7 @@ Fifth Floor, Boston, MA 02110-1301, USA.</translation>
     <message>
         <location filename="../application.cpp" line="190"/>
         <source>Set mode of desktop wallpaper. MODE=(color|stretch|fit|center|tile)</source>
-        <translation>Définir le mode de fond d&apos;écran de bureau. MODE=(couleur|étirer|ajuster|centrer|découper)</translation>
+        <translation>Définir le mode de fond d&apos;écran de bureau. MODE=(color|stretch|fit|center|tile)</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="190"/>

--- a/pcmanfm/translations/pcmanfm-qt_ru.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ru.ts
@@ -881,7 +881,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Бостон, MA  02110-1301,
     <message>
         <location filename="../application.cpp" line="193"/>
         <source>Set mode of desktop wallpaper. MODE=(color|stretch|fit|center|tile)</source>
-        <translation>Выбрать режим обоев рабочего стола. РЕЖИМ=(цвет|растянуть|вместить|по центру|черепицей)</translation>
+        <translation>Выбрать режим обоев рабочего стола. РЕЖИМ=(color|stretch|fit|center|tile)</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="193"/>


### PR DESCRIPTION
Four translations translated the names of wallpaper modes and therefore provided a wrong description for the --help option. The modes must not be translated because the application only accepts untranslated names.

Thanks!
