### PR TITLE
Prevent large gaps at desktop bottom

### DIFF
--- a/pcmanfm/desktopitemdelegate.cpp
+++ b/pcmanfm/desktopitemdelegate.cpp
@@ -34,7 +34,8 @@ DesktopItemDelegate::DesktopItemDelegate(QListView* view, QObject* parent):
   QStyledItemDelegate(parent ? parent : view),
   view_(view),
   symlinkIcon_(QIcon::fromTheme("emblem-symbolic-link")),
-  shadowColor_(0, 0, 0) {
+  shadowColor_(0, 0, 0),
+  margins_(QSize(3, 3)) {
 }
 
 // FIXME: we need to figure out a way to derive from Fm::FolderItemDelegate to avoid code duplication.
@@ -74,7 +75,7 @@ void DesktopItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
   }
 
   // draw text
-  QSize gridSize = view_->gridSize() - QSize(6, 6);
+  QSize gridSize = view_->gridSize() - 2 * margins_;
   QRectF textRect(opt.rect.x() - (gridSize.width() - opt.rect.width()) / 2,
                   opt.rect.y() + opt.decorationSize.height(),
                   gridSize.width(),
@@ -189,8 +190,7 @@ QSize DesktopItemDelegate::sizeHint(const QStyleOptionViewItem& option, const QM
   opt.decorationAlignment = Qt::AlignHCenter|Qt::AlignTop;
   opt.displayAlignment = Qt::AlignTop|Qt::AlignHCenter;
 
-  QSize gridSize = view_->gridSize()
-                   - QSize(6, 6); // a 6-px margin is added at FolderView::updateGridSize()
+  QSize gridSize = view_->gridSize() - 2 * margins_;
   Q_ASSERT(gridSize != QSize());
   QRectF textRect(0, 0, gridSize.width(), gridSize.height() - opt.decorationSize.height());
   drawText(NULL, opt, textRect); // passing NULL for painter will calculate the bounding rect only.

--- a/pcmanfm/desktopitemdelegate.h
+++ b/pcmanfm/desktopitemdelegate.h
@@ -45,6 +45,9 @@ public:
   const QColor& shadowColor() const {
     return shadowColor_;
   }
+  void setMargins(QSize margins) {
+    margins_ = margins.expandedTo(QSize(0, 0));
+  }
 
 private:
   void drawText(QPainter* painter, QStyleOptionViewItemV4& opt, QRectF& textRect) const;
@@ -53,6 +56,7 @@ private:
   QListView* view_;
   QIcon symlinkIcon_;
   QColor shadowColor_;
+  QSize margins_;
 };
 
 }

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -441,8 +441,8 @@ void DesktopWindow::onIndexesMoved(const QModelIndexList& indexes) {
       workArea.adjust(12, 12, -12, -12);
       if(customItemPos_.keys(tl).isEmpty() // don't put items on each other
          && tl.x() >= workArea.x() && tl.y() >= workArea.y()
-         && tl.x() + listView_->gridSize().width() <= workArea.right()
-         && tl.y() + listView_->gridSize().height() <= workArea.bottom()) {
+         && tl.x() + listView_->gridSize().width() <= workArea.right() + 1 // for historical reasons (-> Qt doc)
+         && tl.y() + listView_->gridSize().height() <= workArea.bottom() + 1) { // as above
         QByteArray name = fm_file_info_get_name(file);
         customItemPos_[name] = tl;
         // qDebug() << "indexMoved:" << name << index << itemRect;
@@ -451,6 +451,43 @@ void DesktopWindow::onIndexesMoved(const QModelIndexList& indexes) {
   }
   saveItemPositions();
   queueRelayout();
+}
+
+void DesktopWindow::removeBottomGap() {
+  /************************************************************
+   NOTE: Desktop is an area bounded from below while icons snap
+   to its grid srarting from above. Therefore, we try to adjust
+   the vertical cell margin to prevent relatively large gaps
+   from taking shape at the desktop bottom.
+   ************************************************************/
+  QSize cellMargins = getMargins();
+  int workAreaHeight = qApp->desktop()->availableGeometry(screenNum_).height()
+                       - 24; // a 12-pix margin will be considered everywhere
+  int cellHeight = listView_->gridSize().height() + listView_->spacing();
+  int iconNumber = workAreaHeight / cellHeight;
+  int bottomGap = workAreaHeight % cellHeight;
+  /*******************************************
+   First try to make room for an extra icon...
+   *******************************************/
+  // If one pixel is subtracted from the vertical margin, cellHeight
+  // will decrease by 2 while bottomGap will increase by 2*iconNumber.
+  // So, we can add an icon to the bottom once this inequality holds:
+  // bottomGap + 2*n*iconNumber >= cellHeight - 2*n
+  // From here, we get our "subtrahend":
+  qreal exactNumber = ((qreal)cellHeight - (qreal)bottomGap)
+                      / (2.0 * (qreal)iconNumber + 2.0);
+  int subtrahend = (int)exactNumber + ((int)exactNumber == exactNumber ? 0 : 1);
+  if(subtrahend < cellMargins.height()) { // lack of margin doesn't seem good
+    cellMargins -= QSize(0, subtrahend);
+  }
+  /***************************************************
+   ... but if that can't be done, try to spread icons!
+   ***************************************************/
+  else
+    cellMargins += QSize(0, (bottomGap / iconNumber) / 2);
+  // set the new margins (if they're changed)
+  delegate_->setMargins(cellMargins);
+  setMargins(cellMargins);
 }
 
 // QListView does item layout in a very inflexible way, so let's do our custom layout again.
@@ -513,13 +550,13 @@ void DesktopWindow::relayoutItems() {
       }
       // move to next cell in the column
       pos.setY(pos.y() + grid.height() + listView_->spacing());
-      if(pos.y() + grid.height() > workArea.bottom()) {
+      if(pos.y() + grid.height() > workArea.bottom() + 1) {
         // if the next position may exceed the bottom of work area, go to the top of next column
         pos.setX(pos.x() + grid.width() + listView_->spacing());
         pos.setY(workArea.top());
 
         // check if the new column exceeds the right margin of work area
-        if(pos.x() + grid.width() > workArea.right()) {
+        if(pos.x() + grid.width() > workArea.right() + 1) {
           if(desktop->isVirtualDesktop()) {
             // in virtual desktop mode, go to next screen
             ++screen;
@@ -555,8 +592,8 @@ void DesktopWindow::loadItemPositions() {
     if(var.isValid()) {
       QPoint customPos = var.toPoint();
       if (customPos.x() >= workArea.x() && customPos.y() >= workArea.y()
-          && customPos.x() + listView_->gridSize().width() <= workArea.right()
-          && customPos.y() + listView_->gridSize().height() <= workArea.bottom())
+          && customPos.x() + listView_->gridSize().width() <= workArea.right() + 1
+          && customPos.y() + listView_->gridSize().height() <= workArea.bottom() + 1)
       {
         // correct positions that are't aligned to the grid
         qreal w = qAbs((qreal)customPos.x() - (qreal)workArea.x())
@@ -567,7 +604,7 @@ void DesktopWindow::loadItemPositions() {
         customPos.setY(workArea.y() + qRound(h) * (grid.height() + listView_->spacing()));
         while(customItemPos_.values().contains(customPos)) {
           customPos.setY(customPos.y() + grid.height() + listView_->spacing());
-          if(customPos.y() + grid.height() > workArea.bottom()) {
+          if(customPos.y() + grid.height() > workArea.bottom() + 1) {
             customPos.setX(customPos.x() + grid.width() + listView_->spacing());
             customPos.setY(workArea.top());
           }
@@ -625,6 +662,7 @@ void DesktopWindow::onStickToCurrentPos(bool toggled) {
 
 void DesktopWindow::queueRelayout(int delay) {
   // qDebug() << "queueRelayout";
+  removeBottomGap();
   if(!relayoutTimer_) {
     relayoutTimer_ = new QTimer();
     relayoutTimer_->setSingleShot(true);

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -114,6 +114,9 @@ protected Q_SLOTS:
   void onFilePropertiesActivated();
 
 private:
+  void removeBottomGap();
+
+private:
   Fm::ProxyFolderModel* proxyModel_;
   Fm::CachedFolderModel* model_;
   FmFolder* folder_;


### PR DESCRIPTION
Here the meaning of "large" depends on several parameters. This commit is based on https://github.com/lxde/libfm-qt/pull/13 and solves https://github.com/lxde/pcmanfm-qt/issues/97#issuecomment-170671223 by first trying to make room for an extra icon at the bottom and then, if not possible, spreading icons vertically. I encountered both possibilities by changing font/icon sizes and it worked in all cases.