### PR TITLE
Fixed a crash on right clicking trashed files.

### DIFF
--- a/pcmanfm/view.cpp
+++ b/pcmanfm/view.cpp
@@ -118,8 +118,10 @@ void View::prepareFileMenu(Fm::FileMenu* menu) {
     }
   }
   else {
-    menu->pasteAction()->setVisible(false);
-    menu->createAction()->setVisible(false);
+    if(menu->pasteAction()) // NULL for trash
+      menu->pasteAction()->setVisible(false);
+    if(menu->createAction())
+      menu->createAction()->setVisible(false);
   }
 }
 


### PR DESCRIPTION
Probably after https://github.com/lxde/pcmanfm-qt/pull/278, PCManFM crashed when a file was right clicked inside Trash because trashed files don't have a paste action (-> libfm-qt -> FileMenu::createMenu()).