### PR TITLE
Added options for min. item margins.

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -201,6 +201,82 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="title">
+          <string>Spacing</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Minimum item margins:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="hMargin">
+            <property name="toolTip">
+             <string>3 px by default.</string>
+            </property>
+            <property name="suffix">
+             <string> px</string>
+            </property>
+            <property name="maximum">
+             <number>48</number>
+            </property>
+            <property name="value">
+             <number>3</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>x</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QSpinBox" name="vMargin">
+            <property name="toolTip">
+             <string>1 px by default.
+A space is also reserved for 3 lines of text.</string>
+            </property>
+            <property name="suffix">
+             <string> px</string>
+            </property>
+            <property name="maximum">
+             <number>48</number>
+            </property>
+            <property name="value">
+             <number>1</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QCheckBox" name="lockMargins">
+            <property name="text">
+             <string>Lock</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>5</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -87,6 +87,10 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
 
   connect(ui.buttonBox->button(QDialogButtonBox::Apply), &QPushButton::clicked,
           this, &DesktopPreferencesDialog::onApplyClicked);
+
+  ui.hMargin->setValue(settings.desktopCellMargins().width());
+  ui.vMargin->setValue(settings.desktopCellMargins().height());
+  connect(ui.lockMargins, &QAbstractButton::clicked, this, &DesktopPreferencesDialog::lockMargins);
 }
 
 DesktopPreferencesDialog::~DesktopPreferencesDialog() {
@@ -108,6 +112,16 @@ void DesktopPreferencesDialog::setupDesktopFolderUi()
     this, &DesktopPreferencesDialog::onBrowseDesktopFolderClicked);
 }
 
+void DesktopPreferencesDialog::lockMargins(bool lock) {
+  ui.vMargin->setDisabled(lock);
+  if(lock) {
+    ui.vMargin->setValue(ui.hMargin->value());
+    connect(ui.hMargin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), ui.vMargin, &QSpinBox::setValue);
+  }
+  else
+    disconnect(ui.hMargin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), ui.vMargin, &QSpinBox::setValue);
+}
+
 void DesktopPreferencesDialog::applySettings()
 {
   Settings& settings = static_cast<Application*>(qApp)->settings();
@@ -123,6 +137,7 @@ void DesktopPreferencesDialog::applySettings()
   settings.setDesktopFgColor(ui.textColor->color());
   settings.setDesktopShadowColor(ui.shadowColor->color());
   settings.setShowWmMenu(ui.showWmMenu->isChecked());
+  settings.setDesktopCellMargins(QSize(ui.hMargin->value(), ui.vMargin->value()));
 
   settings.save();
 }

--- a/pcmanfm/desktoppreferencesdialog.h
+++ b/pcmanfm/desktoppreferencesdialog.h
@@ -47,6 +47,7 @@ protected Q_SLOTS:
   void onWallpaperModeChanged(int index);
   void onBrowseClicked();
   void onBrowseDesktopFolderClicked();
+  void lockMargins(bool lock);
 
   void applySettings();
 

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -344,7 +344,8 @@ void DesktopWindow::updateFromSettings(Settings& settings) {
   setWallpaperMode(settings.wallpaperMode());
   setFont(settings.desktopFont());
   setIconSize(Fm::FolderView::IconMode, QSize(settings.bigIconSize(), settings.bigIconSize()));
-  // setIconSize may trigger relayout of items by QListView, so we need to do the layout again.
+  setMargins(settings.desktopCellMargins());
+  // setIconSize and setMargins may trigger relayout of items by QListView, so we need to do the layout again.
   queueRelayout();
   setForeground(settings.desktopFgColor());
   setBackground(settings.desktopBgColor());
@@ -477,7 +478,10 @@ void DesktopWindow::removeBottomGap() {
   qreal exactNumber = ((qreal)cellHeight - (qreal)bottomGap)
                       / (2.0 * (qreal)iconNumber + 2.0);
   int subtrahend = (int)exactNumber + ((int)exactNumber == exactNumber ? 0 : 1);
-  if(subtrahend < cellMargins.height()) { // lack of margin doesn't seem good
+  Settings& settings = static_cast<Application*>(qApp)->settings();
+  int minCellHeight = settings.desktopCellMargins().height();
+  if(subtrahend > 0
+     && cellMargins.height() - subtrahend >= minCellHeight) {
     cellMargins -= QSize(0, subtrahend);
   }
   /***************************************************
@@ -488,6 +492,8 @@ void DesktopWindow::removeBottomGap() {
   // set the new margins (if they're changed)
   delegate_->setMargins(cellMargins);
   setMargins(cellMargins);
+  // in case the text shadow is reset to (0,0,0,0)
+  setShadow(settings.desktopShadowColor());
 }
 
 // QListView does item layout in a very inflexible way, so let's do our custom layout again.

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -291,22 +291,22 @@
            <property name="title">
             <string>User interface</string>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_8">
-            <item>
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="0" column="0" colspan="6">
              <widget class="QCheckBox" name="siUnit">
               <property name="text">
                <string>Use SI decimal prefixes instead of IEC binary prefixes</string>
               </property>
              </widget>
             </item>
-            <item>
+            <item row="1" column="0" colspan="6">
              <widget class="QCheckBox" name="backupAsHidden">
               <property name="text">
                <string>Treat backup files as hidden</string>
               </property>
              </widget>
             </item>
-            <item>
+            <item row="2" column="0" colspan="6">
              <widget class="QCheckBox" name="showFullNames">
               <property name="enabled">
                <bool>false</bool>
@@ -316,7 +316,7 @@
               </property>
              </widget>
             </item>
-            <item>
+            <item row="3" column="0" colspan="6">
              <widget class="QCheckBox" name="shadowHidden">
               <property name="enabled">
                <bool>false</bool>
@@ -325,6 +325,89 @@
                <string>Show icons of hidden files shadowed</string>
               </property>
              </widget>
+            </item>
+            <item row="4" column="0">
+             <spacer name="verticalSpacer_7">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>5</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_15">
+              <property name="text">
+               <string>Minimum item margins in icon view:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QSpinBox" name="hMargin">
+              <property name="toolTip">
+               <string>3 px by default.</string>
+              </property>
+              <property name="suffix">
+               <string> px</string>
+              </property>
+              <property name="maximum">
+               <number>48</number>
+              </property>
+              <property name="value">
+               <number>3</number>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="2">
+             <widget class="QLabel" name="label_16">
+              <property name="text">
+               <string>x</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="3">
+             <widget class="QSpinBox" name="vMargin">
+              <property name="toolTip">
+               <string>3 px by default.
+A space is also reserved for 3 lines of text.</string>
+              </property>
+              <property name="suffix">
+               <string> px</string>
+              </property>
+              <property name="maximum">
+               <number>48</number>
+              </property>
+              <property name="value">
+               <number>3</number>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="4">
+             <widget class="QCheckBox" name="lockMargins">
+              <property name="text">
+               <string>Lock</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="5">
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>5</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </widget>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -112,6 +112,10 @@ void PreferencesDialog::initIconThemes(Settings& settings) {
     ui.iconThemeLabel->hide();
     ui.iconTheme->hide();
   }
+
+  ui.hMargin->setValue(settings.folderViewCellMargins().width());
+  ui.vMargin->setValue(settings.folderViewCellMargins().height());
+  connect(ui.lockMargins, &QAbstractButton::clicked, this, &PreferencesDialog::lockMargins);
 }
 
 void PreferencesDialog::initArchivers(Settings& settings) {
@@ -283,6 +287,7 @@ void PreferencesDialog::applyDisplayPage(Settings& settings) {
   settings.setBackupAsHidden(ui.backupAsHidden->isChecked());
   settings.setShowFullNames(ui.showFullNames->isChecked());
   settings.setShadowHidden(ui.shadowHidden->isChecked());
+  settings.setFolderViewCellMargins(QSize(ui.hMargin->value(), ui.vMargin->value()));
 }
 
 void PreferencesDialog::applyUiPage(Settings& settings) {
@@ -364,6 +369,16 @@ void PreferencesDialog::selectPage(QString name) {
       ui.listWidget->setCurrentRow(index);
     }
   }
+}
+
+void PreferencesDialog::lockMargins(bool lock) {
+  ui.vMargin->setDisabled(lock);
+  if(lock) {
+    ui.vMargin->setValue(ui.hMargin->value());
+    connect(ui.hMargin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), ui.vMargin, &QSpinBox::setValue);
+  }
+  else
+    disconnect(ui.hMargin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), ui.vMargin, &QSpinBox::setValue);
 }
 
 } // namespace PCManFM

--- a/pcmanfm/preferencesdialog.h
+++ b/pcmanfm/preferencesdialog.h
@@ -42,6 +42,9 @@ public:
 
   void selectPage(QString name);
 
+protected Q_SLOTS:
+  void lockMargins(bool lock);
+
 private:
   void initIconThemes(Settings& settings);
   void initArchivers(Settings& settings);

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -106,7 +106,9 @@ Settings::Settings():
   bigIconSize_(48),
   smallIconSize_(24),
   sidePaneIconSize_(24),
-  thumbnailIconSize_(128) {
+  thumbnailIconSize_(128),
+  folderViewCellMargins_(QSize(3, 3)),
+  desktopCellMargins_(QSize(3, 1)) {
 }
 
 Settings::~Settings() {
@@ -201,6 +203,9 @@ bool Settings::loadFile(QString filePath) {
 
   desktopSortOrder_ = sortOrderFromString(settings.value("SortOrder").toString());
   desktopSortColumn_ = sortColumnFromString(settings.value("SortColumn").toString());
+
+  desktopCellMargins_ = (settings.value("DesktopCellMargins", QSize(3, 1)).toSize()
+                         .expandedTo(QSize(0, 0))).boundedTo(QSize(48, 48));
   settings.endGroup();
 
   settings.beginGroup("Volume");
@@ -233,6 +238,9 @@ bool Settings::loadFile(QString filePath) {
   smallIconSize_ = settings.value("SmallIconSize", 24).toInt();
   sidePaneIconSize_ = settings.value("SidePaneIconSize", 24).toInt();
   thumbnailIconSize_ = settings.value("ThumbnailIconSize", 128).toInt();
+
+  folderViewCellMargins_ = (settings.value("FolderViewCellMargins", QSize(3, 3)).toSize()
+                            .expandedTo(QSize(0, 0))).boundedTo(QSize(48, 48));
   settings.endGroup();
 
   settings.beginGroup("Places");
@@ -302,6 +310,7 @@ bool Settings::saveFile(QString filePath) {
   settings.setValue("ShowHidden", desktopShowHidden_);
   settings.setValue("SortOrder", sortOrderToString(desktopSortOrder_));
   settings.setValue("SortColumn", sortColumnToString(desktopSortColumn_));
+  settings.setValue("DesktopCellMargins", desktopCellMargins_);
   settings.endGroup();
 
   settings.beginGroup("Volume");
@@ -334,6 +343,8 @@ bool Settings::saveFile(QString filePath) {
   settings.setValue("SmallIconSize", smallIconSize_);
   settings.setValue("SidePaneIconSize", sidePaneIconSize_);
   settings.setValue("ThumbnailIconSize", thumbnailIconSize_);
+
+  settings.setValue("FolderViewCellMargins", folderViewCellMargins_);
   settings.endGroup();
 
   settings.beginGroup("Places");

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -503,6 +503,23 @@ public:
     return thumbnailIconSize_;
   }
 
+  QSize folderViewCellMargins() const {
+    return folderViewCellMargins_;
+  }
+
+  void setFolderViewCellMargins(QSize size) {
+    folderViewCellMargins_ = size;
+  }
+
+  QSize desktopCellMargins() const {
+    return desktopCellMargins_;
+  }
+
+  void setDesktopCellMargins(QSize size) {
+    desktopCellMargins_ = size;
+  }
+
+
   bool showThumbnails() {
     return showThumbnails_;
   }
@@ -673,6 +690,9 @@ private:
   bool onlyUserTemplates_;
   bool templateTypeOnce_;
   bool templateRunApp_;
+
+  QSize folderViewCellMargins_;
+  QSize desktopCellMargins_;
 };
 
 }

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -85,6 +85,7 @@ TabPage::TabPage(FmPath* path, QWidget* parent):
   verticalLayout->setContentsMargins(0, 0, 0, 0);
 
   folderView_ = new View(settings.viewMode(), this);
+  folderView_->setMargins(settings.folderViewCellMargins());
   // newView->setColumnWidth(Fm::FolderModel::ColumnName, 200);
   connect(folderView_, &View::openDirRequested, this, &TabPage::onOpenDirRequested);
   connect(folderView_, &View::selChanged, this, &TabPage::onSelChanged);

--- a/pcmanfm/view.cpp
+++ b/pcmanfm/view.cpp
@@ -135,6 +135,8 @@ void View::updateFromSettings(Settings& settings) {
   setIconSize(Fm::FolderView::ThumbnailMode, QSize(settings.thumbnailIconSize(), settings.thumbnailIconSize()));
   setIconSize(Fm::FolderView::DetailedListMode, QSize(settings.smallIconSize(), settings.smallIconSize()));
 
+  setMargins(settings.folderViewCellMargins());
+
   setAutoSelectionDelay(settings.autoSelectionDelay());
 
   Fm::ProxyFolderModel* proxyModel = model();

--- a/pcmanfm/view.h
+++ b/pcmanfm/view.h
@@ -41,6 +41,13 @@ public:
 
   void updateFromSettings(Settings& settings);
 
+  QSize  getMargins() const {
+    return Fm::FolderView::getMargins();
+  }
+  void setMargins(QSize size) {
+    Fm::FolderView::setMargins(size);
+  }
+
 Q_SIGNALS:
   void openDirRequested(FmPath* path, int target);
 


### PR DESCRIPTION
Fixes https://github.com/lxde/lxqt/issues/786. Two options are added, one for folder-view (Display section) and the other for desktop (General section). Min. horizontal and vertical margins can be set independently. A max. value of 48px is chosen, which gives a min. spacing of 96px.

Since the default margin is just 3px, these options are mostly useful for those who want a greater distance between items, especially in folder-view.