### PR TITLE
Update the tab bar visibility when the settings change

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -973,10 +973,7 @@ void MainWindow::updateFromSettings(Settings& settings) {
 
   // tabs
   ui.tabBar->setTabsClosable(settings.showTabClose());
-
-  if(!settings.alwaysShowTabs()) {
-    ui.tabBar->setVisible(ui.tabBar->count() > 1);
-  }
+  ui.tabBar->setVisible(settings.alwaysShowTabs() || (ui.tabBar->count() > 1));
 
   // all tab pages
   int n = ui.stackedWidget->count();


### PR DESCRIPTION
Currently when changing the tab bar visibility in the settings, the ui is not updated to reflect the new setting, with this pull request, it is.