### PR TITLE
Return focus to the folder view when hitting escape

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -166,6 +166,9 @@ MainWindow::MainWindow(FmPath* path):
 
   // create shortcuts
   QShortcut* shortcut;
+  shortcut = new QShortcut(QKeySequence(Qt::Key_Escape), this);
+  connect(shortcut, &QShortcut::activated, this, &MainWindow::onResetFocus);
+
   shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_L), this);
   connect(shortcut, &QShortcut::activated, this, &MainWindow::focusPathEntry);
 
@@ -497,6 +500,12 @@ void MainWindow::on_actionThumbnailView_triggered() {
 
 void MainWindow::onTabBarCloseRequested(int index) {
   closeTab(index);
+}
+
+void MainWindow::onResetFocus() {
+  if(TabPage* page = currentPage()) {
+    currentPage()->folderView()->childView()->setFocus();
+  }
 }
 
 void MainWindow::onTabBarTabMoved(int from, int to) {

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -140,6 +140,7 @@ protected Q_SLOTS:
   void onSidePaneCreateNewFolderRequested(FmPath* path);
   void onSidePaneModeChanged(Fm::SidePane::Mode mode);
   void onSplitterMoved(int pos, int index);
+  void onResetFocus();
 
   void onBackForwardContextMenu(QPoint pos);
 


### PR DESCRIPTION
This pull request makes it possible to use escape to "reset" the focus, or more precisely to return it to the folderview of the current tab page. This is quite handy when using pcmanfm with the keyboard.

This pull request relies on: https://github.com/lxde/libfm-qt/pull/18