### PR TITLE
Optional tabbar stretching

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -85,6 +85,10 @@ MainWindow::MainWindow(FmPath* path):
   ui.tabBar->setElideMode(Qt::ElideRight);
   ui.tabBar->setExpanding(false);
   ui.tabBar->setMovable(true); // reorder the tabs by dragging
+  if(!settings.fullWidthTabBar()) {
+    ui.verticalLayout->removeWidget(ui.tabBar);
+    ui.verticalLayout_2->insertWidget(0, ui.tabBar);
+  }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
   // switch to the tab under the cursor during dnd.
@@ -1037,6 +1041,16 @@ void MainWindow::updateFromSettings(Settings& settings) {
   // tabs
   ui.tabBar->setTabsClosable(settings.showTabClose());
   ui.tabBar->setVisible(settings.alwaysShowTabs() || (ui.tabBar->count() > 1));
+  if(ui.verticalLayout->indexOf(ui.tabBar) > -1) {
+    if(!settings.fullWidthTabBar()) {
+      ui.verticalLayout->removeWidget(ui.tabBar);
+      ui.verticalLayout_2->insertWidget(0, ui.tabBar);
+    }
+  }
+  else if (ui.verticalLayout_2->indexOf(ui.tabBar) > -1 && settings.fullWidthTabBar()) {
+    ui.verticalLayout_2->removeWidget(ui.tabBar);
+    ui.verticalLayout->insertWidget(0, ui.tabBar);
+  }
 
   // all tab pages
   int n = ui.stackedWidget->count();

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -446,42 +446,53 @@ A space is also reserved for 3 lines of text.</string>
              </widget>
             </item>
             <item row="1" column="0" colspan="2">
+             <widget class="QCheckBox" name="fullWidthTabbar">
+              <property name="toolTip">
+               <string>If unchecked, the tab bar will be positioned only
+above the folder-view and not above the left pane.</string>
+              </property>
+              <property name="text">
+               <string>Fullwidth tab bar</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="2">
              <widget class="QCheckBox" name="showTabClose">
               <property name="text">
                <string>Show 'Close' buttons on tabs	</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="0" colspan="2">
+            <item row="3" column="0" colspan="2">
              <widget class="QCheckBox" name="rememberWindowSize">
               <property name="text">
                <string>Remember the size of the last closed window</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="0">
+            <item row="4" column="0">
              <widget class="QLabel" name="label_12">
               <property name="text">
                <string>Default width of new windows:</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
+            <item row="4" column="1">
+             <widget class="QSpinBox" name="fixedWindowWidth">
+              <property name="maximum">
+               <number>32768</number>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0">
              <widget class="QLabel" name="label_13">
               <property name="text">
                <string>Default height of new windows:</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="1">
+            <item row="5" column="1">
              <widget class="QSpinBox" name="fixedWindowHeight">
-              <property name="maximum">
-               <number>32768</number>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QSpinBox" name="fixedWindowWidth">
               <property name="maximum">
                <number>32768</number>
               </property>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -170,6 +170,7 @@ void PreferencesDialog::initDisplayPage(Settings& settings) {
 
 void PreferencesDialog::initUiPage(Settings& settings) {
   ui.alwaysShowTabs->setChecked(settings.alwaysShowTabs());
+  ui.fullWidthTabbar->setChecked(settings.fullWidthTabBar());
   ui.showTabClose->setChecked(settings.showTabClose());
   ui.rememberWindowSize->setChecked(settings.rememberWindowSize());
   ui.fixedWindowWidth->setValue(settings.fixedWindowWidth());
@@ -292,6 +293,7 @@ void PreferencesDialog::applyDisplayPage(Settings& settings) {
 
 void PreferencesDialog::applyUiPage(Settings& settings) {
   settings.setAlwaysShowTabs(ui.alwaysShowTabs->isChecked());
+  settings.setFullWidthTabBar(ui.fullWidthTabbar->isChecked());
   settings.setShowTabClose(ui.showTabClose->isChecked());
   settings.setRememberWindowSize(ui.rememberWindowSize->isChecked());
   settings.setFixedWindowWidth(ui.fixedWindowWidth->value());

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -80,6 +80,7 @@ Settings::Settings():
   splitterPos_(120),
   sidePaneMode_(Fm::SidePane::ModePlaces),
   showMenuBar_(true),
+  fullWidthTabBar_(true),
   viewMode_(Fm::FolderView::IconMode),
   showHidden_(false),
   sortOrder_(Qt::AscendingOrder),
@@ -266,6 +267,7 @@ bool Settings::loadFile(QString filePath) {
   splitterPos_ = settings.value("SplitterPos", 150).toInt();
   sidePaneMode_ = sidePaneModeFromString(settings.value("SidePaneMode").toString());
   showMenuBar_ = settings.value("ShowMenuBar", true).toBool();
+  fullWidthTabBar_ = settings.value("FullWidthTabBar", true).toBool();
   settings.endGroup();
 
   return true;
@@ -371,6 +373,7 @@ bool Settings::saveFile(QString filePath) {
   settings.setValue("SplitterPos", splitterPos_);
   settings.setValue("SidePaneMode", sidePaneModeToString(sidePaneMode_));
   settings.setValue("ShowMenuBar", showMenuBar_);
+  settings.setValue("FullWidthTabBar", fullWidthTabBar_);
   settings.endGroup();
   return true;
 }

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -314,6 +314,14 @@ public:
     showMenuBar_ = showMenuBar;
   }
 
+  bool fullWidthTabBar() const {
+    return fullWidthTabBar_;
+  }
+
+  void setFullWidthTabBar(bool fullWith) {
+    fullWidthTabBar_ = fullWith;
+  }
+
   Fm::FolderView::ViewMode viewMode() const {
     return viewMode_;
   }
@@ -658,6 +666,7 @@ private:
   int splitterPos_;
   Fm::SidePane::Mode sidePaneMode_;
   bool showMenuBar_;
+  bool fullWidthTabBar_;
 
   Fm::FolderView::ViewMode viewMode_;
   bool showHidden_;


### PR DESCRIPTION
By default, the tabbar is stretched over the left pane too. This commit makes that optional with a check button in the View menu. It's checked by default but if unchecked, the tabbar will be positioned right above the folder-view.

Theoretically, the tabbar could be positioned at the bottom, right or left too but, IMO, such positions aren't practical in the case of PCManFM.