### PR TITLE
Switch automatically to newly opened tabs

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -279,7 +279,7 @@ void MainWindow::chdir(FmPath* path) {
 }
 
 // add a new tab
-void MainWindow::addTab(FmPath* path) {
+int MainWindow::addTab(FmPath* path) {
   Settings& settings = static_cast<Application*>(qApp)->settings();
 
   TabPage* newPage = new TabPage(path, this);
@@ -297,6 +297,8 @@ void MainWindow::addTab(FmPath* path) {
   if(!settings.alwaysShowTabs()) {
     ui.tabBar->setVisible(ui.tabBar->count() > 1);
   }
+
+  return index;
 }
 
 void MainWindow::toggleMenuBar(bool checked) {
@@ -375,7 +377,8 @@ void MainWindow::on_actionGo_triggered() {
 
 void MainWindow::on_actionNewTab_triggered() {
   FmPath* path = currentPage()->path();
-  addTab(path);
+  int index = addTab(path);
+  ui.tabBar->setCurrentIndex(index);
 }
 
 void MainWindow::on_actionNewWin_triggered() {

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -45,7 +45,7 @@ public:
   virtual ~MainWindow();
 
   void chdir(FmPath* path);
-  void addTab(FmPath* path);
+  int addTab(FmPath* path);
 
   TabPage* currentPage() {
     return reinterpret_cast<TabPage*>(ui.stackedWidget->currentWidget());


### PR DESCRIPTION
This feels a bit more natural as it matches the usual behaviour of tabbed applications, although the difference is small since the new tabs are opened in the same directory.

This only applies to when the user requests a new "empty" tab, so for example opening something in a new tab with a middle click still opens the tab in the background.