### PR TITLE
Fixes libfm-qt dependency contradiction on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 The Qt port of the LXDE file manager PCManFM.
 
-Includes libfm-qt, the Qt port of the libfm - a library providing components to
-build desktop file managers.
-
 Issue tracker:
   https://github.com/lxde/pcmanfm-qt/issues
 


### PR DESCRIPTION
libfm-qt and pcmanfm-qt were split. This is just and artifact.
Closes #331.