### PR TITLE
Add setting for Desktop con size

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -114,6 +114,25 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_5">
+         <property name="title">
+          <string>Icons</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Icon size:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="iconSize"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
           <string>Label Text</string>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -33,6 +33,8 @@
 
 namespace PCManFM {
 
+static int iconSizes[] = {96, 72, 64, 48, 36, 32, 24, 20};
+
 DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFlags f):
   QDialog(parent, f),
   editDesktopFolderEnabled(false),
@@ -77,6 +79,13 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   connect(ui.browse, &QPushButton::clicked, this, &DesktopPreferencesDialog::onBrowseClicked);
   qDebug("wallpaper: %s", settings.wallpaper().toUtf8().data());
   ui.imageFile->setText(settings.wallpaper());
+
+  for(int i = 0; i < G_N_ELEMENTS(iconSizes); ++i) {
+    int size = iconSizes[i];
+    ui.iconSize->addItem(QString("%1 x %1").arg(size), size);
+    if(settings.desktopIconSize() == size)
+      ui.iconSize->setCurrentIndex(i);
+  }
 
   ui.font->setFont(settings.desktopFont());
 
@@ -132,6 +141,7 @@ void DesktopPreferencesDialog::applySettings()
   settings.setWallpaper(ui.imageFile->text());
   int mode = ui.wallpaperMode->itemData(ui.wallpaperMode->currentIndex()).toInt();
   settings.setWallpaperMode(mode);
+  settings.setDesktopIconSize(ui.iconSize->itemData(ui.iconSize->currentIndex()).toInt());
   settings.setDesktopFont(ui.font->font());
   settings.setDesktopBgColor(ui.backgroundColor->color());
   settings.setDesktopFgColor(ui.textColor->color());

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -343,7 +343,7 @@ void DesktopWindow::updateFromSettings(Settings& settings) {
   setWallpaperFile(settings.wallpaper());
   setWallpaperMode(settings.wallpaperMode());
   setFont(settings.desktopFont());
-  setIconSize(Fm::FolderView::IconMode, QSize(settings.bigIconSize(), settings.bigIconSize()));
+  setIconSize(Fm::FolderView::IconMode, QSize(settings.desktopIconSize(), settings.desktopIconSize()));
   setMargins(settings.desktopCellMargins());
   // setIconSize and setMargins may trigger relayout of items by QListView, so we need to do the layout again.
   queueRelayout();

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -65,6 +65,7 @@ Settings::Settings():
   desktopBgColor_(),
   desktopFgColor_(),
   desktopShadowColor_(),
+  desktopIconSize_(48),
   showWmMenu_(false),
   desktopShowHidden_(false),
   desktopSortOrder_(Qt::AscendingOrder),
@@ -200,6 +201,7 @@ bool Settings::loadFile(QString filePath) {
     desktopFont_.fromString(settings.value("Font").toString());
   else
     desktopFont_ = QApplication::font();
+  desktopIconSize_ = settings.value("DesktopIconSize", 48).toInt();
   showWmMenu_ = settings.value("ShowWmMenu", false).toBool();
   desktopShowHidden_ = settings.value("ShowHidden", false).toBool();
 
@@ -310,6 +312,7 @@ bool Settings::saveFile(QString filePath) {
   settings.setValue("FgColor", desktopFgColor_.name());
   settings.setValue("ShadowColor", desktopShadowColor_.name());
   settings.setValue("Font", desktopFont_.toString());
+  settings.setValue("DesktopIconSize", desktopIconSize_);
   settings.setValue("ShowWmMenu", showWmMenu_);
   settings.setValue("ShowHidden", desktopShowHidden_);
   settings.setValue("SortOrder", sortOrderToString(desktopSortOrder_));

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -185,6 +185,14 @@ public:
     desktopFont_ = font;
   }
 
+  int desktopIconSize() const {
+    return desktopIconSize_;
+  }
+
+  void setDesktopIconSize(int desktopIconSize) {
+    desktopIconSize_ = desktopIconSize;
+  }
+
   bool showWmMenu() const {
     return showWmMenu_;
   }
@@ -649,6 +657,7 @@ private:
   QColor desktopFgColor_;
   QColor desktopShadowColor_;
   QFont desktopFont_;
+  int desktopIconSize_;
   bool showWmMenu_;
 
   bool desktopShowHidden_;


### PR DESCRIPTION
Since Desktop has its own font and spacing settings, it seems logical to give it a separate setting for icon size too (see https://github.com/lxde/pcmanfm-qt/issues/334#issuecomment-205264654).