### PR TITLE
Reading and save desktop item sorting

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -96,12 +96,14 @@ DesktopWindow::DesktopWindow(int screenNum):
     proxyModel_ = new Fm::ProxyFolderModel();
     proxyModel_->setSourceModel(model_);
     proxyModel_->setShowThumbnails(settings.showThumbnails());
-    proxyModel_->sort(Fm::FolderModel::ColumnFileMTime);
+    proxyModel_->sort(settings.desktopSortColumn(), settings.desktopSortOrder());
+    proxyModel_->setFolderFirst(settings.desktopSortFolderFirst());
     setModel(proxyModel_);
 
     connect(proxyModel_, &Fm::ProxyFolderModel::rowsInserted, this, &DesktopWindow::onRowsInserted);
     connect(proxyModel_, &Fm::ProxyFolderModel::rowsAboutToBeRemoved, this, &DesktopWindow::onRowsAboutToBeRemoved);
     connect(proxyModel_, &Fm::ProxyFolderModel::layoutChanged, this, &DesktopWindow::onLayoutChanged);
+    connect(proxyModel_, &Fm::ProxyFolderModel::sortFilterChanged, this, &DesktopWindow::onModelSortFilterChanged);
     connect(listView_, &QListView::indexesMoved, this, &DesktopWindow::onIndexesMoved);
   }
 
@@ -424,6 +426,13 @@ void DesktopWindow::onRowsAboutToBeRemoved(const QModelIndex& parent, int start,
 
 void DesktopWindow::onLayoutChanged() {
   queueRelayout();
+}
+
+void DesktopWindow::onModelSortFilterChanged() {
+  Settings& settings = static_cast<Application*>(qApp)->settings();
+  settings.setDesktopSortColumn(static_cast<Fm::FolderModel::ColumnId>(proxyModel_->sortColumn()));
+  settings.setDesktopSortOrder(proxyModel_->sortOrder());
+  settings.setSesktopSortFolderFirst(proxyModel_->folderFirst());
 }
 
 void DesktopWindow::onIndexesMoved(const QModelIndexList& indexes) {

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -98,6 +98,7 @@ protected Q_SLOTS:
   void onRowsAboutToBeRemoved(const QModelIndex& parent, int start, int end);
   void onRowsInserted(const QModelIndex& parent, int start, int end);
   void onLayoutChanged();
+  void onModelSortFilterChanged();
   void onIndexesMoved(const QModelIndexList& indexes);
 
   void relayoutItems();

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -69,7 +69,8 @@ Settings::Settings():
   showWmMenu_(false),
   desktopShowHidden_(false),
   desktopSortOrder_(Qt::AscendingOrder),
-  desktopSortColumn_(Fm::FolderModel::ColumnFileName),
+  desktopSortColumn_(Fm::FolderModel::ColumnFileMTime),
+  desktopSortFolderFirst_(true),
   alwaysShowTabs_(true),
   showTabClose_(true),
   rememberWindowSize_(true),
@@ -207,6 +208,7 @@ bool Settings::loadFile(QString filePath) {
 
   desktopSortOrder_ = sortOrderFromString(settings.value("SortOrder").toString());
   desktopSortColumn_ = sortColumnFromString(settings.value("SortColumn").toString());
+  desktopSortFolderFirst_ = settings.value("SortFolderFirst", true).toBool();
 
   desktopCellMargins_ = (settings.value("DesktopCellMargins", QSize(3, 1)).toSize()
                          .expandedTo(QSize(0, 0))).boundedTo(QSize(48, 48));
@@ -317,6 +319,7 @@ bool Settings::saveFile(QString filePath) {
   settings.setValue("ShowHidden", desktopShowHidden_);
   settings.setValue("SortOrder", sortOrderToString(desktopSortOrder_));
   settings.setValue("SortColumn", sortColumnToString(desktopSortColumn_));
+  settings.setValue("SortFolderFirst", desktopSortFolderFirst_);
   settings.setValue("DesktopCellMargins", desktopCellMargins_);
   settings.endGroup();
 

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -225,6 +225,14 @@ public:
     desktopSortColumn_ = desktopSortColumn;
   }
 
+  bool desktopSortFolderFirst() const {
+    return desktopSortFolderFirst_;
+  }
+
+  void setSesktopSortFolderFirst(bool desktopFolderFirst) {
+    desktopSortFolderFirst_ = desktopFolderFirst;
+  }
+
   bool alwaysShowTabs() const {
     return alwaysShowTabs_;
   }
@@ -663,6 +671,7 @@ private:
   bool desktopShowHidden_;
   Qt::SortOrder desktopSortOrder_;
   Fm::FolderModel::ColumnId desktopSortColumn_;
+  bool desktopSortFolderFirst_;
 
   bool alwaysShowTabs_;
   bool showTabClose_;


### PR DESCRIPTION
The desktop sorting wasn't read or saved before!

@pmattern
Please test it thoroughly so that we won't bother PCMan for merging it!

The default sorting should be as before (time+ascending+folders-first).