### PR TITLE
Per-folder saving of sorting and view mode

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -347,6 +347,24 @@ void Application::onUserDirsChanged()
 
 void Application::onAboutToQuit() {
   qDebug("aboutToQuit");
+  // remove non-existent folders from the list of custom folders
+  QString configFile = QString("%1/perfolder-settings.conf").arg(settings_.profileDir(settings_.profileName()));
+  QSettings folderSettings(configFile, QSettings::IniFormat);
+  QHash<QString, QVariant> customFolders = folderSettings.value("customFolders").toHash();
+  if(!customFolders.isEmpty()) {
+    //qDebug() << "Custom folders: " << customFolders.keys();
+    QHash<QString, QVariant>::iterator i = customFolders.begin();
+    while (i != customFolders.end()) {
+      QDir dir(i.key());
+      if(!dir.exists()) {
+        i = customFolders.erase(i);
+      }
+      else ++i;
+    }
+    folderSettings.setValue("customFolders", customFolders);
+  }
+  if(customFolders.isEmpty())
+    folderSettings.clear();
   settings_.save();
 }
 

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -145,6 +145,9 @@
      <string>&amp;View</string>
     </property>
     <widget class="QMenu" name="menuSorting">
+     <property name="tearOffEnabled">
+      <bool>true</bool>
+     </property>
      <property name="title">
       <string>&amp;Sorting</string>
      </property>
@@ -159,16 +162,29 @@
      <addaction name="separator"/>
      <addaction name="actionFolderFirst"/>
      <addaction name="actionCaseSensitive"/>
+     <addaction name="separator"/>
+     <addaction name="actionPreserveSorting"/>
+    </widget>
+    <widget class="QMenu" name="menu_View_2">
+     <property name="tearOffEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="title">
+      <string>&amp;View</string>
+     </property>
+     <addaction name="actionIconView"/>
+     <addaction name="actionThumbnailView"/>
+     <addaction name="actionCompactView"/>
+     <addaction name="actionDetailedList"/>
+     <addaction name="separator"/>
+     <addaction name="actionPreserveView"/>
     </widget>
     <addaction name="actionReload"/>
     <addaction name="actionShowHidden"/>
     <addaction name="separator"/>
-    <addaction name="actionIconView"/>
-    <addaction name="actionThumbnailView"/>
-    <addaction name="actionCompactView"/>
-    <addaction name="actionDetailedList"/>
-    <addaction name="separator"/>
+    <addaction name="menu_View_2"/>
     <addaction name="menuSorting"/>
+    <addaction name="separator"/>
     <addaction name="actionFilter"/>
     <addaction name="actionMenu_bar"/>
    </widget>
@@ -531,6 +547,14 @@
     <string>&amp;Folder First</string>
    </property>
   </action>
+  <action name="actionPreserveSorting">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Preserve sorting for this folder</string>
+   </property>
+  </action>
   <action name="actionNewTab">
    <property name="icon">
     <iconset theme="window-new">
@@ -758,6 +782,14 @@
    </property>
    <property name="toolTip">
     <string>Menu</string>
+   </property>
+  </action>
+  <action name="actionPreserveView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Preserve view for this folder</string>
    </property>
   </action>
  </widget>

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -30,6 +30,7 @@
 #include <QShortcut>
 #include <QKeySequence>
 #include <QDir>
+#include <QSettings>
 #include <QDebug>
 
 #include "tabpage.h"
@@ -499,6 +500,78 @@ void MainWindow::on_actionFolderFirst_triggered(bool checked) {
   currentPage()->setSortFolderFirst(checked);
 }
 
+/* When the box is checked, save the sorting in 'perfolder-settings.conf'.
+   When unchecked, revert to the default sorting and remove the sorting keys
+   from the conf file or remove the folder path from it if the view mode
+   isn't customized either. */
+void MainWindow::on_actionPreserveSorting_triggered(bool checked) {
+  TabPage* page = currentPage();
+  if(page) {
+    FmFolder* folder = page->folder();
+    if(folder) {
+      Settings& settings = static_cast<Application*>(qApp)->settings();
+      QString configFile = QString("%1/perfolder-settings.conf").arg(settings.profileDir(settings.profileName()));
+      QSettings file(configFile, QSettings::IniFormat);
+      // we use a nested QHash<QString(folder), QHash<QString(property), QVariant(value)>>
+      QHash<QString, QVariant> customFolders = file.value("customFolders").toHash();
+      FmPath* path = fm_folder_get_path(folder);
+      char* pathStr = fm_path_to_str(path);
+      QString folder(pathStr);
+      g_free(pathStr);
+      QHash<QString, QVariant> props = customFolders.value(folder).toHash();
+
+      if(!checked) {
+        if(props.contains("Mode")) {
+          props.remove("SortColumn");
+          props.remove("SortFolderFirst");
+          props.remove("SortOrder");
+          customFolders.insert(folder, props);
+        }
+        else
+          customFolders.remove(folder);
+        file.setValue("customFolders", customFolders);
+        page->sort(settings.sortColumn(), settings.sortOrder());
+        page->setSortFolderFirst(settings.sortFolderFirst());
+        page->setSortCaseSensitive(false);
+      }
+      else {
+        int columnId;
+        switch(static_cast<Fm::FolderModel::ColumnId>(page->sortColumn())) {
+          case Fm::FolderModel::ColumnFileName:
+          default:
+            columnId = 0;
+            break;
+          case Fm::FolderModel::ColumnFileType:
+            columnId = 1;
+            break;
+          case Fm::FolderModel::ColumnFileSize:
+            columnId = 2;
+            break;
+          case Fm::FolderModel::ColumnFileMTime:
+            columnId = 3;
+            break;
+          case Fm::FolderModel::ColumnFileOwner:
+            columnId = 4;
+            break;
+        }
+        int order = page->sortOrder() == Qt::AscendingOrder ? 0 : 1;
+        bool folderFirst(page->sortFolderFirst());
+        /* this may be called by onTabPageSortFilterChanged() without change in sorting
+           and we don't want a redundant writng of the same QHash in a different form */
+        if(props.value("SortColumn").toInt() == columnId
+           && props.value("SortFolderFirst").toBool() == folderFirst
+           && props.value("SortOrder").toInt() == order)
+          return;
+        props.insert("SortColumn", QVariant(columnId));
+        props.insert("SortFolderFirst", QVariant(folderFirst));
+        props.insert("SortOrder", QVariant(order));
+        customFolders.insert(folder, props);
+        file.setValue("customFolders", customFolders);
+      }
+    }
+  }
+}
+
 void MainWindow::on_actionFilter_triggered(bool checked) {
   ui.filterBar->setVisible(checked);
   if(checked)
@@ -579,18 +652,104 @@ void MainWindow::on_actionAbout_triggered() {
 
 void MainWindow::on_actionIconView_triggered() {
   currentPage()->setViewMode(Fm::FolderView::IconMode);
+  saveViewMode();
 }
 
 void MainWindow::on_actionCompactView_triggered() {
   currentPage()->setViewMode(Fm::FolderView::CompactMode);
+  saveViewMode();
 }
 
 void MainWindow::on_actionDetailedList_triggered() {
   currentPage()->setViewMode(Fm::FolderView::DetailedListMode);
+  saveViewMode();
 }
 
 void MainWindow::on_actionThumbnailView_triggered() {
   currentPage()->setViewMode(Fm::FolderView::ThumbnailMode);
+  saveViewMode();
+}
+
+void MainWindow::saveViewMode()
+{
+  if(ui.actionPreserveView->isChecked())
+    on_actionPreserveView_triggered(true);
+  else {
+    Settings& settings = static_cast<Application*>(qApp)->settings();
+    settings.setViewMode(currentPage()->viewMode());
+  }
+}
+
+/* When the box is checked, save the view mode in 'perfolder-settings.conf'.
+   When unchecked, revert to the default view mode and remove the mode key
+   from the conf file or remove the folder path from it if the sorting isn't
+   customized either. */
+void MainWindow::on_actionPreserveView_triggered(bool checked) {
+  TabPage* page = currentPage();
+  if(page) {
+    FmFolder* folder = page->folder();
+    if(folder) {
+      Settings& settings = static_cast<Application*>(qApp)->settings();
+      QString configFile = QString("%1/perfolder-settings.conf").arg(settings.profileDir(settings.profileName()));
+      QSettings file(configFile, QSettings::IniFormat);
+      QHash<QString, QVariant> customFolders = file.value("customFolders").toHash();
+      FmPath* path = fm_folder_get_path(folder);
+      char* pathStr = fm_path_to_str(path);
+      QString folder(pathStr);
+      g_free(pathStr);
+      QHash<QString, QVariant> props = customFolders.value(folder).toHash();
+
+      if(!checked) {
+        if(props.contains("SortColumn"))
+        {
+          props.remove("Mode");
+          customFolders.insert(folder, props);
+        }
+        else
+          customFolders.remove(folder);
+        file.setValue("customFolders", customFolders);
+        if(page->viewMode() != settings.viewMode()) {
+          page->setViewMode(settings.viewMode());
+          switch(settings.viewMode()) { // there's no slot to set checkboxes
+          case Fm::FolderView::IconMode:
+          default:
+            ui.actionIconView->setChecked(true);
+            break;
+          case Fm::FolderView::CompactMode:
+            ui.actionCompactView->setChecked(true);
+            break;
+          case Fm::FolderView::DetailedListMode:
+            ui.actionDetailedList->setChecked(true);
+            break;
+          case Fm::FolderView::ThumbnailMode:
+            ui.actionThumbnailView->setChecked(true);
+            break;
+          }
+        }
+      }
+      else {
+        int viewMode;
+        switch(page->viewMode()) {
+          case Fm::FolderView::IconMode:
+          default:
+            viewMode = 0;
+            break;
+          case Fm::FolderView::CompactMode:
+            viewMode = 1;
+            break;
+          case Fm::FolderView::DetailedListMode:
+            viewMode = 2;
+            break;
+          case Fm::FolderView::ThumbnailMode:
+            viewMode = 3;
+            break;
+        }
+        props.insert("Mode", QVariant(viewMode));
+        customFolders.insert(folder, props);
+        file.setValue("customFolders", customFolders);
+      }
+    }
+  }
 }
 
 void MainWindow::onTabBarCloseRequested(int index) {
@@ -739,6 +898,27 @@ void MainWindow::updateViewMenuForCurrentPage() {
 
     ui.actionCaseSensitive->setChecked(tabPage->sortCaseSensitive());
     ui.actionFolderFirst->setChecked(tabPage->sortFolderFirst());
+
+    // see if this folder is customized
+    ui.actionPreserveSorting->setChecked(false);
+    ui.actionPreserveView->setChecked(false);
+    FmFolder* folder = tabPage->folder();
+    if(folder) {
+      Settings& settings = static_cast<Application*>(qApp)->settings();
+      QString configFile = QString("%1/perfolder-settings.conf").arg(settings.profileDir(settings.profileName()));
+      QSettings file(configFile, QSettings::IniFormat);
+      QHash<QString, QVariant> customFolders = file.value("customFolders").toHash();
+      FmPath* path = fm_folder_get_path(folder);
+      char* pathStr = fm_path_to_str(path);
+      QString folder(pathStr);
+      g_free(pathStr);
+      QHash<QString, QVariant> props = customFolders.value(folder).toHash();
+      if(props.isEmpty()) return;
+      if(props.contains("SortColumn"))
+        ui.actionPreserveSorting->setChecked(true);
+      if(props.contains("Mode"))
+        ui.actionPreserveView->setChecked(true);
+    }
   }
 }
 
@@ -760,6 +940,43 @@ void MainWindow::updateUIForCurrentPage() {
     ui.actionGoUp->setEnabled(tabPage->canUp());
     ui.actionGoBack->setEnabled(tabPage->canBackward());
     ui.actionGoForward->setEnabled(tabPage->canForward());
+
+    // update view mode when needed, considering customized folders
+    FmFolder* folder = tabPage->folder();
+    if(folder) {
+      Settings& settings = static_cast<Application*>(qApp)->settings();
+      QString configFile = QString("%1/perfolder-settings.conf").arg(settings.profileDir(settings.profileName()));
+      QSettings file(configFile, QSettings::IniFormat);
+      QHash<QString, QVariant> customFolders = file.value("customFolders").toHash();
+      FmPath* path = fm_folder_get_path(folder);
+      char* pathStr = fm_path_to_str(path);
+      QString folder(pathStr);
+      g_free(pathStr);
+      QHash<QString, QVariant> props = customFolders.value(folder).toHash();
+      if(props.contains("Mode")) {
+        int viewMode = props.value("Mode").toInt();
+        Fm::FolderView::ViewMode vm;
+        switch(viewMode) {
+          case 0:
+          default:
+            vm = Fm::FolderView::IconMode;
+            break;
+          case 1:
+            vm = Fm::FolderView::CompactMode;
+            break;
+          case 2:
+            vm = Fm::FolderView::DetailedListMode;
+            break;
+          case 3:
+            vm = Fm::FolderView::ThumbnailMode;
+            break;
+        }
+        if(tabPage->viewMode() != vm)
+          tabPage->setViewMode(vm);
+      }
+      else if (tabPage->viewMode() != settings.viewMode()) // always revert to the default mode
+        tabPage->setViewMode(settings.viewMode());
+    }
 
     updateViewMenuForCurrentPage();
     updateStatusBarForCurrentPage();
@@ -837,10 +1054,14 @@ void MainWindow::onTabPageSortFilterChanged() {
 
   if(tabPage == currentPage()) {
     updateViewMenuForCurrentPage();
-    Settings& settings = static_cast<Application*>(qApp)->settings();
-    settings.setSortColumn(static_cast<Fm::FolderModel::ColumnId>(tabPage->sortColumn()));
-    settings.setSortOrder(tabPage->sortOrder());
-    settings.setSortFolderFirst(tabPage->sortFolderFirst());
+    if(ui.actionPreserveSorting->isChecked())
+      on_actionPreserveSorting_triggered(true);
+    else {
+      Settings& settings = static_cast<Application*>(qApp)->settings();
+      settings.setSortColumn(static_cast<Fm::FolderModel::ColumnId>(tabPage->sortColumn()));
+      settings.setSortOrder(tabPage->sortOrder());
+      settings.setSortFolderFirst(tabPage->sortFolderFirst());
+    }
   }
 }
 

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -86,6 +86,7 @@ protected Q_SLOTS:
   void on_actionCompactView_triggered();
   void on_actionDetailedList_triggered();
   void on_actionThumbnailView_triggered();
+  void on_actionPreserveView_triggered(bool checked);
 
   void on_actionGo_triggered();
   void on_actionShowHidden_triggered(bool check);
@@ -99,6 +100,7 @@ protected Q_SLOTS:
   void on_actionDescending_triggered(bool checked);
   void on_actionFolderFirst_triggered(bool checked);
   void on_actionCaseSensitive_triggered(bool checked);
+  void on_actionPreserveSorting_triggered(bool checked);
   void on_actionFilter_triggered(bool checked);
 
   void on_actionApplications_triggered();
@@ -169,6 +171,7 @@ private:
   void updateViewMenuForCurrentPage();
   void updateStatusBarForCurrentPage();
   void setRTLIcons(bool isRTL);
+  void saveViewMode();
 
 private:
   Ui::MainWindow ui;


### PR DESCRIPTION
Separate per-folder savings of sorting and view mode is added to the View sub-menus as check boxes. All settings are saved to and retrieved from `~/.config/pcmanfm-qt/PROFILE/perfolder-settings.conf`. If a box is checked, the current folder will have its own sorting or view mode, which could be changed in the corresponding sub-menu later. If unchecked, the default will be used again.

With this commit, it's possible, for example, to set the wallpaper folder in the thumbnail mode while using the default sorting for it, *and* sort the download folder according to mod. time while it's shown in the default view mode.