### PR TITLE
Fix memory leak in main window tool bar

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -173,7 +173,7 @@ MainWindow::MainWindow(FmPath* path):
   addActions(ui.menubar->actions());
 
   // Show or hide the menu bar
-  QMenu *menu = new QMenu();
+  QMenu *menu = new QMenu(ui.toolBar);
   menu->addMenu(ui.menu_File);
   menu->addMenu(ui.menu_Editw);
   menu->addMenu(ui.menu_View);


### PR DESCRIPTION
The replacement main menu had no parent and was therefore not deleted.

Found by Valgrind.

Thanks!