### PR TITLE
Re-layout on Changing Display Name.

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -446,8 +446,8 @@ void DesktopWindow::onDataChanged(const QModelIndex& topLeft, const QModelIndex&
     for(int i = topLeft.row(); i <= bottomRight.row(); ++i) {
       QModelIndex index = topLeft.sibling(i, 0);
       if(index.isValid() && displayNames_.contains(index)) {
-        FmFileInfo* file = proxyModel_->fileInfoFromIndex(index);
-        if(displayNames_[index] != fm_file_info_get_disp_name(file)) {
+        Fm::FileInfo file = proxyModel_->fileInfoFromIndex(index);
+        if(displayNames_[index] != file.getDispName()) {
           relayout = true;
           break;
         }

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -104,6 +104,7 @@ DesktopWindow::DesktopWindow(int screenNum):
     connect(proxyModel_, &Fm::ProxyFolderModel::rowsAboutToBeRemoved, this, &DesktopWindow::onRowsAboutToBeRemoved);
     connect(proxyModel_, &Fm::ProxyFolderModel::layoutChanged, this, &DesktopWindow::onLayoutChanged);
     connect(proxyModel_, &Fm::ProxyFolderModel::sortFilterChanged, this, &DesktopWindow::onModelSortFilterChanged);
+    connect(proxyModel_, &Fm::ProxyFolderModel::dataChanged, this, &DesktopWindow::onDataChanged);
     connect(listView_, &QListView::indexesMoved, this, &DesktopWindow::onIndexesMoved);
   }
 
@@ -433,6 +434,33 @@ void DesktopWindow::onModelSortFilterChanged() {
   settings.setSesktopSortFolderFirst(proxyModel_->folderFirst());
 }
 
+void DesktopWindow::onDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight) {
+  /****************************************************************************
+   NOTE: The display names of desktop entries and shortcuts may change without
+   their files being renamed and, on such occasions, a relayout will be needed.
+   Since there is no signal for that, we use the signal dataChanged() and the
+   QHash displayNames_, which remembers such display names with every relayout.
+   ****************************************************************************/
+  if(topLeft.column() == 0) {
+    bool relayout(false);
+    for(int i = topLeft.row(); i <= bottomRight.row(); ++i) {
+      QModelIndex index = topLeft.sibling(i, 0);
+      if(index.isValid() && displayNames_.contains(index)) {
+        FmFileInfo* file = proxyModel_->fileInfoFromIndex(index);
+        if(displayNames_[index] != fm_file_info_get_disp_name(file)) {
+          relayout = true;
+          break;
+        }
+      }
+    }
+    if(relayout) {
+      queueRelayout();
+      // parts of the old display name might still be visible if it's long
+      listView_->viewport()->update();
+    }
+  }
+}
+
 void DesktopWindow::onIndexesMoved(const QModelIndexList& indexes) {
   // remember the custom position for the items
   Q_FOREACH(const QModelIndex& index, indexes) {
@@ -506,6 +534,7 @@ void DesktopWindow::removeBottomGap() {
 // QListView does item layout in a very inflexible way, so let's do our custom layout again.
 // FIXME: this is very inefficient, but due to the design flaw of QListView, this is currently the only workaround.
 void DesktopWindow::relayoutItems() {
+  displayNames_.clear();
   loadItemPositions(); // something may have changed
   // qDebug("relayoutItems()");
   if(relayoutTimer_) {
@@ -535,6 +564,9 @@ void DesktopWindow::relayoutItems() {
       QModelIndex index = proxyModel_->index(row, 0);
       int itemWidth = delegate_->sizeHint(listView_->getViewOptions(), index).width();
       Fm::FileInfo file = proxyModel_->fileInfoFromIndex(index);
+      // remember display names of desktop entries and shortcuts
+      if(file.isDesktopEntry() || file.isShortcut())
+        displayNames_[index] = QString(file.getDispName());
       QByteArray name = file.getName();
       QHash<QByteArray, QPoint>::iterator it = customItemPos_.find(name);
       if(it != customItemPos_.end()) { // the item has a custom position

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -102,6 +102,7 @@ protected Q_SLOTS:
   void onLayoutChanged();
   void onModelSortFilterChanged();
   void onIndexesMoved(const QModelIndexList& indexes);
+  void onDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);
 
   void relayoutItems();
   void onStickToCurrentPos(bool toggled);
@@ -137,6 +138,7 @@ private:
 
   int screenNum_;
   QHash<QByteArray, QPoint> customItemPos_;
+  QHash<QModelIndex, QString> displayNames_; // only for desktop entries and shortcuts
   QTimer* relayoutTimer_;
 };
 


### PR DESCRIPTION
Fixes https://github.com/lxde/lxqt/issues/1061.

When the sorting is not by name, if the display name of a desktop entry or shortcut file on the desktop changes without change in its file name, a re-layout should be done; otherwise, the item might be out of grid until the next desktop refresh.
