### PR TITLE
Fix some icons for RTL

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -718,7 +718,7 @@
      <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
-    <string>Close &amp;left tabs</string>
+    <string>Close &amp;previous tabs</string>
    </property>
   </action>
   <action name="actionCloseRight">
@@ -727,7 +727,7 @@
      <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
-    <string>Close &amp;right tabs</string>
+    <string>Close &amp;next tabs</string>
    </property>
   </action>
   <action name="actionCloseOther">

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -259,6 +259,9 @@ MainWindow::MainWindow(FmPath* path):
     if(settings.windowMaximized())
       setWindowState(windowState() | Qt::WindowMaximized);
   }
+
+  if(QApplication::layoutDirection() == Qt::RightToLeft)
+    setRTLIcons(true);
 }
 
 MainWindow::~MainWindow() {
@@ -976,15 +979,34 @@ void MainWindow::on_actionPreferences_triggered() {
   app->preferences(QString());
 }
 
-/*
-void MainWindow::changeEvent(QEvent* event) {
+// change some icons according to layout direction
+void MainWindow::setRTLIcons(bool isRTL) {
+  QIcon nxtIcn = QIcon::fromTheme("go-next");
+  QIcon prevIcn = QIcon::fromTheme("go-previous");
+  if(isRTL) {
+    ui.actionGoBack->setIcon(nxtIcn);
+    ui.actionCloseLeft->setIcon(nxtIcn);
+    ui.actionGoForward->setIcon(prevIcn);
+    ui.actionCloseRight->setIcon(prevIcn);
+  }
+  else {
+    ui.actionGoBack->setIcon(prevIcn);
+    ui.actionCloseLeft->setIcon(prevIcn);
+    ui.actionGoForward->setIcon(nxtIcn);
+    ui.actionCloseRight->setIcon(nxtIcn);
+  }
+}
+
+void MainWindow::changeEvent(QEvent *event) {
   switch(event->type()) {
-    case QEvent::StyleChange:
+    case QEvent::LayoutDirectionChange:
+      setRTLIcons(QApplication::layoutDirection() == Qt::RightToLeft);
+      break;
+    default:
       break;
   }
   QWidget::changeEvent(event);
 }
-*/
 
 void MainWindow::onBackForwardContextMenu(QPoint pos) {
   // show a popup menu for browsing history here.

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -156,7 +156,7 @@ protected Q_SLOTS:
   void toggleMenuBar(bool checked);
 
 protected:
-  // void changeEvent( QEvent * event);
+  void changeEvent(QEvent *event);
   void closeTab(int index);
   virtual void resizeEvent(QResizeEvent *event);
   virtual void closeEvent(QCloseEvent *event);
@@ -167,6 +167,7 @@ private:
   void updateUIForCurrentPage();
   void updateViewMenuForCurrentPage();
   void updateStatusBarForCurrentPage();
+  void setRTLIcons(bool isRTL);
 
 private:
   Ui::MainWindow ui;


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/305.

It also responds to `QEvent::LayoutDirectionChange` but (1) changing the layout direction should be done outside PCManFM-Qt and for all apps, and (2) Qt has small bugs concerning on-the-fly change of layout direction. All in all, IMO, it's good to be thorough when the required changes are small.