### PR TITLE
Replace tilde with home path

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -382,6 +382,7 @@ void MainWindow::on_actionHome_triggered() {
 
 void MainWindow::on_actionReload_triggered() {
   currentPage()->reload();
+  pathEntry->setText(currentPage()->pathName());
 }
 
 void MainWindow::on_actionGo_triggered() {

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -29,6 +29,7 @@
 #include <QToolButton>
 #include <QShortcut>
 #include <QKeySequence>
+#include <QDir>
 #include <QDebug>
 
 #include "tabpage.h"
@@ -128,6 +129,7 @@ MainWindow::MainWindow(FmPath* path):
   // path bar
   pathEntry = new Fm::PathEdit(this);
   connect(pathEntry, &Fm::PathEdit::returnPressed, this, &MainWindow::onPathEntryReturnPressed);
+  connect(pathEntry, &QLineEdit::textEdited, this, &MainWindow::onPathEntryEdited);
   ui.toolBar->insertWidget(ui.actionGo, pathEntry);
 
   // add filesystem info to status bar
@@ -334,6 +336,14 @@ void MainWindow::onPathEntryReturnPressed() {
   FmPath* path = fm_path_new_for_display_name(utext);
   chdir(path);
   fm_path_unref(path);
+}
+
+void MainWindow::onPathEntryEdited(const QString& text) {
+  QString realText(text);
+  if(realText == "~" || realText.startsWith("~/")) {
+    realText.replace(0, 1, QDir::homePath());
+    pathEntry->setText(realText);
+  }
 }
 
 void MainWindow::on_actionGoUp_triggered() {

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -56,6 +56,7 @@ public:
 protected Q_SLOTS:
 
   void onPathEntryReturnPressed();
+  void onPathEntryEdited(const QString& text);
 
   void on_actionNewTab_triggered();
   void on_actionNewWin_triggered();


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/369.

As soon as the user types or pastes a path string starting with a tilde (in the form of `~` or `~/...`) in the location bar, the tilde is replaced by `QDir::homePath()`.