### PR TITLE
I18N: Fix plural string

### DIFF
--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -434,7 +434,7 @@ void TabPage::onSelChanged(int numSel) {
     else {
       goffset sum;
       GList* l;
-      msg = tr("%n item(s) selected", NULL, numSel).arg(numSel);
+      msg = tr("%n item(s) selected", nullptr, numSel).arg(numSel);
       /* don't count if too many files are selected, that isn't lightweight */
       if(numSel < 1000) {
         sum = 0;

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -434,7 +434,7 @@ void TabPage::onSelChanged(int numSel) {
     else {
       goffset sum;
       GList* l;
-      msg = tr("%1 item(s) selected", NULL, numSel).arg(numSel);
+      msg = tr("%n item(s) selected", NULL, numSel).arg(numSel);
       /* don't count if too many files are selected, that isn't lightweight */
       if(numSel < 1000) {
         sum = 0;


### PR DESCRIPTION
The selected tabs label's string isn't treated as plural.
Just fixed the placeholder according to Qt docs.