### PR TITLE
Fix direction of statusbar message

### DIFF
--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -224,6 +224,7 @@ protected Q_SLOTS:
 private:
   void freeFolder();
   QString formatStatusText();
+  static void directedText(QString &txt, QChar startMark = QChar(), QChar endMark = QChar());
 
   static void onFolderStartLoading(FmFolder* _folder, TabPage* pThis);
   static void onFolderFinishLoading(FmFolder* _folder, TabPage* pThis);


### PR DESCRIPTION
Event for LTR layouts, a file can have an RTL name or an LTR name with an RTL component. So, the direction of statusbar text should be corrected with LRM/RLM and LRE/RLE; otherwise the message would be scrambled in such cases.
