### PR TITLE
Replaces deprecated QStyleOptionViewItemV4

### DIFF
--- a/pcmanfm/desktopitemdelegate.cpp
+++ b/pcmanfm/desktopitemdelegate.cpp
@@ -41,7 +41,7 @@ DesktopItemDelegate::DesktopItemDelegate(QListView* view, QObject* parent):
 // FIXME: we need to figure out a way to derive from Fm::FolderItemDelegate to avoid code duplication.
 void DesktopItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const {
   Q_ASSERT(index.isValid());
-  QStyleOptionViewItemV4 opt = option;
+  QStyleOptionViewItem opt = option;
   initStyleOption(&opt, index);
 
   painter->save();
@@ -88,7 +88,7 @@ void DesktopItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
   painter->restore();
 }
 
-void DesktopItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& opt, QRectF& textRect) const {
+void DesktopItemDelegate::drawText(QPainter* painter, QStyleOptionViewItem& opt, QRectF& textRect) const {
   QTextLayout layout(opt.text, opt.font);
 
   QTextOption textOption;
@@ -137,7 +137,7 @@ void DesktopItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& op
   if (opt.state & QStyle::State_Selected || opt.state & QStyle::State_MouseOver) {
     if (const QWidget* widget = opt.widget) { // let the style engine do it
       QStyle* style = widget->style() ? widget->style() : qApp->style();
-      QStyleOptionViewItemV4 o(opt);
+      QStyleOptionViewItem o(opt);
       o.text = QString();
       o.rect = selRect.toAlignedRect().intersected(opt.rect); // due to clipping and rounding, we might lose 1px
       o.showDecorationSelected = true;
@@ -185,7 +185,7 @@ QSize DesktopItemDelegate::sizeHint(const QStyleOptionViewItem& option, const QM
   QVariant value = index.data(Qt::SizeHintRole);
   if(value.isValid())
     return qvariant_cast<QSize>(value);
-  QStyleOptionViewItemV4 opt = option;
+  QStyleOptionViewItem opt = option;
   initStyleOption(&opt, index);
   opt.decorationAlignment = Qt::AlignHCenter|Qt::AlignTop;
   opt.displayAlignment = Qt::AlignTop|Qt::AlignHCenter;

--- a/pcmanfm/desktopitemdelegate.h
+++ b/pcmanfm/desktopitemdelegate.h
@@ -50,7 +50,7 @@ public:
   }
 
 private:
-  void drawText(QPainter* painter, QStyleOptionViewItemV4& opt, QRectF& textRect) const;
+  void drawText(QPainter* painter, QStyleOptionViewItem& opt, QRectF& textRect) const;
 
 private:
   QListView* view_;


### PR DESCRIPTION
QStyleOptionViewItemV4 is just a synonym for QStyleOptionViewItem.
Cleaner builds.