### PR TITLE
Use LXQtCompilerSettings cmake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,33 +28,7 @@ option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" O
 include(GNUInstallDirs)
 include(LXQtTranslateTs)
 include(LXQtTranslateDesktop)
-
-# set visibility to hidden to hide symbols, unless they're exported manually in the code
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
-
-if (CMAKE_VERSION VERSION_LESS "3.1")
-    include(CheckCXXCompilerFlag)
-    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-    if(COMPILER_SUPPORTS_CXX11)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    else()
-        CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-        # -std=c++0x is deprecated but some tools e.g. qmake or older gcc are still using it
-        if(COMPILER_SUPPORTS_CXX0X)
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-        else()
-            message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER} does not support c++11/c++0x")
-        endif()
-    endif()
-else()
-  set(CMAKE_CXX_STANDARD 11)
-endif()
-
-if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    # set visibility to hidden to hide symbols, unless they're exported manually in the code
-    set(CMAKE_CXX_FLAGS "-fno-exceptions ${CMAKE_CXX_FLAGS}")
-endif()
+include(LXQtCompilerSettings NO_POLICY_SCOPE)
 
 set(CMAKE_AUTOMOC TRUE)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)


### PR DESCRIPTION
We already have an build time dependency on liblxqt. So, let's take all the
advantages we can.