### PR TITLE
Per folder settings: a cleaner and simplified implemention.

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -349,24 +349,6 @@ void Application::onUserDirsChanged()
 
 void Application::onAboutToQuit() {
   qDebug("aboutToQuit");
-  // remove non-existent folders from the list of custom folders
-  QString configFile = QString("%1/perfolder-settings.conf").arg(settings_.profileDir(settings_.profileName()));
-  QSettings folderSettings(configFile, QSettings::IniFormat);
-  QHash<QString, QVariant> customFolders = folderSettings.value("customFolders").toHash();
-  if(!customFolders.isEmpty()) {
-    //qDebug() << "Custom folders: " << customFolders.keys();
-    QHash<QString, QVariant>::iterator i = customFolders.begin();
-    while (i != customFolders.end()) {
-      QDir dir(i.key());
-      if(!dir.exists()) {
-        i = customFolders.erase(i);
-      }
-      else ++i;
-    }
-    folderSettings.setValue("customFolders", customFolders);
-  }
-  if(customFolders.isEmpty())
-    folderSettings.clear();
   settings_.save();
 }
 

--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -349,6 +349,24 @@ void Application::onUserDirsChanged()
 
 void Application::onAboutToQuit() {
   qDebug("aboutToQuit");
+  // remove non-existent folders from the list of custom folders
+  QString configFile = QString("%1/perfolder-settings.conf").arg(settings_.profileDir(settings_.profileName()));
+  QSettings folderSettings(configFile, QSettings::IniFormat);
+  QHash<QString, QVariant> customFolders = folderSettings.value("customFolders").toHash();
+  if(!customFolders.isEmpty()) {
+    //qDebug() << "Custom folders: " << customFolders.keys();
+    QHash<QString, QVariant>::iterator i = customFolders.begin();
+    while (i != customFolders.end()) {
+      QDir dir(i.key());
+      if(!dir.exists()) {
+        i = customFolders.erase(i);
+      }
+      else ++i;
+    }
+    folderSettings.setValue("customFolders", customFolders);
+  }
+  if(customFolders.isEmpty())
+    folderSettings.clear();
   settings_.save();
 }
 

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -145,6 +145,9 @@
      <string>&amp;View</string>
     </property>
     <widget class="QMenu" name="menuSorting">
+     <property name="tearOffEnabled">
+      <bool>true</bool>
+     </property>
      <property name="title">
       <string>&amp;Sorting</string>
      </property>
@@ -159,16 +162,29 @@
      <addaction name="separator"/>
      <addaction name="actionFolderFirst"/>
      <addaction name="actionCaseSensitive"/>
+     <addaction name="separator"/>
+     <addaction name="actionPreserveSorting"/>
+    </widget>
+    <widget class="QMenu" name="menu_View_2">
+     <property name="tearOffEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="title">
+      <string>&amp;View</string>
+     </property>
+     <addaction name="actionIconView"/>
+     <addaction name="actionThumbnailView"/>
+     <addaction name="actionCompactView"/>
+     <addaction name="actionDetailedList"/>
+     <addaction name="separator"/>
+     <addaction name="actionPreserveView"/>
     </widget>
     <addaction name="actionReload"/>
     <addaction name="actionShowHidden"/>
     <addaction name="separator"/>
-    <addaction name="actionIconView"/>
-    <addaction name="actionThumbnailView"/>
-    <addaction name="actionCompactView"/>
-    <addaction name="actionDetailedList"/>
-    <addaction name="separator"/>
+    <addaction name="menu_View_2"/>
     <addaction name="menuSorting"/>
+    <addaction name="separator"/>
     <addaction name="actionFilter"/>
     <addaction name="actionMenu_bar"/>
    </widget>
@@ -531,6 +547,14 @@
     <string>&amp;Folder First</string>
    </property>
   </action>
+  <action name="actionPreserveSorting">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Preserve sorting for this folder</string>
+   </property>
+  </action>
   <action name="actionNewTab">
    <property name="icon">
     <iconset theme="window-new">
@@ -758,6 +782,14 @@
    </property>
    <property name="toolTip">
     <string>Menu</string>
+   </property>
+  </action>
+  <action name="actionPreserveView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Preserve view for this folder</string>
    </property>
   </action>
  </widget>

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -86,14 +86,14 @@
         </item>
         <item>
          <widget class="QLineEdit" name="filterBar">
+          <property name="toolTip">
+           <string>Focus with Ctrl+I</string>
+          </property>
           <property name="placeholderText">
            <string>Filter by string...</string>
           </property>
           <property name="clearButtonEnabled">
            <bool>true</bool>
-          </property>
-          <property name="toolTip">
-           <string>Focus with Ctrl+I</string>
           </property>
          </widget>
         </item>
@@ -109,7 +109,7 @@
      <x>0</x>
      <y>0</y>
      <width>460</width>
-     <height>23</height>
+     <height>30</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -145,9 +145,6 @@
      <string>&amp;View</string>
     </property>
     <widget class="QMenu" name="menuSorting">
-     <property name="tearOffEnabled">
-      <bool>true</bool>
-     </property>
      <property name="title">
       <string>&amp;Sorting</string>
      </property>
@@ -162,13 +159,8 @@
      <addaction name="separator"/>
      <addaction name="actionFolderFirst"/>
      <addaction name="actionCaseSensitive"/>
-     <addaction name="separator"/>
-     <addaction name="actionPreserveSorting"/>
     </widget>
     <widget class="QMenu" name="menu_View_2">
-     <property name="tearOffEnabled">
-      <bool>true</bool>
-     </property>
      <property name="title">
       <string>&amp;View</string>
      </property>
@@ -177,13 +169,13 @@
      <addaction name="actionCompactView"/>
      <addaction name="actionDetailedList"/>
      <addaction name="separator"/>
-     <addaction name="actionPreserveView"/>
     </widget>
     <addaction name="actionReload"/>
-    <addaction name="actionShowHidden"/>
     <addaction name="separator"/>
-    <addaction name="menu_View_2"/>
+    <addaction name="actionShowHidden"/>
     <addaction name="menuSorting"/>
+    <addaction name="menu_View_2"/>
+    <addaction name="actionPreserveView"/>
     <addaction name="separator"/>
     <addaction name="actionFilter"/>
     <addaction name="actionMenu_bar"/>
@@ -775,7 +767,8 @@
   </action>
   <action name="actionMenu">
    <property name="icon">
-    <iconset theme="application-menu"/>
+    <iconset theme="application-menu">
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Menu</string>
@@ -789,7 +782,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;Preserve view for this folder</string>
+    <string>&amp;Preserve Settings for This Folder</string>
    </property>
   </action>
  </widget>

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -30,6 +30,7 @@
 #include <QShortcut>
 #include <QKeySequence>
 #include <QDir>
+#include <QSettings>
 #include <QDebug>
 
 #include "tabpage.h"
@@ -493,6 +494,78 @@ void MainWindow::on_actionFolderFirst_triggered(bool checked) {
   currentPage()->setSortFolderFirst(checked);
 }
 
+/* When the box is checked, save the sorting in 'perfolder-settings.conf'.
+   When unchecked, revert to the default sorting and remove the sorting keys
+   from the conf file or remove the folder path from it if the view mode
+   isn't customized either. */
+void MainWindow::on_actionPreserveSorting_triggered(bool checked) {
+  TabPage* page = currentPage();
+  if(page) {
+    FmFolder* folder = page->folder();
+    if(folder) {
+      Settings& settings = static_cast<Application*>(qApp)->settings();
+      QString configFile = QString("%1/perfolder-settings.conf").arg(settings.profileDir(settings.profileName()));
+      QSettings file(configFile, QSettings::IniFormat);
+      // we use a nested QHash<QString(folder), QHash<QString(property), QVariant(value)>>
+      QHash<QString, QVariant> customFolders = file.value("customFolders").toHash();
+      FmPath* path = fm_folder_get_path(folder);
+      char* pathStr = fm_path_to_str(path);
+      QString folder(pathStr);
+      g_free(pathStr);
+      QHash<QString, QVariant> props = customFolders.value(folder).toHash();
+
+      if(!checked) {
+        if(props.contains("Mode")) {
+          props.remove("SortColumn");
+          props.remove("SortFolderFirst");
+          props.remove("SortOrder");
+          customFolders.insert(folder, props);
+        }
+        else
+          customFolders.remove(folder);
+        file.setValue("customFolders", customFolders);
+        page->sort(settings.sortColumn(), settings.sortOrder());
+        page->setSortFolderFirst(settings.sortFolderFirst());
+        page->setSortCaseSensitive(false);
+      }
+      else {
+        int columnId;
+        switch(static_cast<Fm::FolderModel::ColumnId>(page->sortColumn())) {
+          case Fm::FolderModel::ColumnFileName:
+          default:
+            columnId = 0;
+            break;
+          case Fm::FolderModel::ColumnFileType:
+            columnId = 1;
+            break;
+          case Fm::FolderModel::ColumnFileSize:
+            columnId = 2;
+            break;
+          case Fm::FolderModel::ColumnFileMTime:
+            columnId = 3;
+            break;
+          case Fm::FolderModel::ColumnFileOwner:
+            columnId = 4;
+            break;
+        }
+        int order = page->sortOrder() == Qt::AscendingOrder ? 0 : 1;
+        bool folderFirst(page->sortFolderFirst());
+        /* this may be called by onTabPageSortFilterChanged() without change in sorting
+           and we don't want a redundant writng of the same QHash in a different form */
+        if(props.value("SortColumn").toInt() == columnId
+           && props.value("SortFolderFirst").toBool() == folderFirst
+           && props.value("SortOrder").toInt() == order)
+          return;
+        props.insert("SortColumn", QVariant(columnId));
+        props.insert("SortFolderFirst", QVariant(folderFirst));
+        props.insert("SortOrder", QVariant(order));
+        customFolders.insert(folder, props);
+        file.setValue("customFolders", customFolders);
+      }
+    }
+  }
+}
+
 void MainWindow::on_actionFilter_triggered(bool checked) {
   ui.filterBar->setVisible(checked);
   if(checked)
@@ -567,18 +640,104 @@ void MainWindow::on_actionAbout_triggered() {
 
 void MainWindow::on_actionIconView_triggered() {
   currentPage()->setViewMode(Fm::FolderView::IconMode);
+  saveViewMode();
 }
 
 void MainWindow::on_actionCompactView_triggered() {
   currentPage()->setViewMode(Fm::FolderView::CompactMode);
+  saveViewMode();
 }
 
 void MainWindow::on_actionDetailedList_triggered() {
   currentPage()->setViewMode(Fm::FolderView::DetailedListMode);
+  saveViewMode();
 }
 
 void MainWindow::on_actionThumbnailView_triggered() {
   currentPage()->setViewMode(Fm::FolderView::ThumbnailMode);
+  saveViewMode();
+}
+
+void MainWindow::saveViewMode()
+{
+  if(ui.actionPreserveView->isChecked())
+    on_actionPreserveView_triggered(true);
+  else {
+    Settings& settings = static_cast<Application*>(qApp)->settings();
+    settings.setViewMode(currentPage()->viewMode());
+  }
+}
+
+/* When the box is checked, save the view mode in 'perfolder-settings.conf'.
+   When unchecked, revert to the default view mode and remove the mode key
+   from the conf file or remove the folder path from it if the sorting isn't
+   customized either. */
+void MainWindow::on_actionPreserveView_triggered(bool checked) {
+  TabPage* page = currentPage();
+  if(page) {
+    FmFolder* folder = page->folder();
+    if(folder) {
+      Settings& settings = static_cast<Application*>(qApp)->settings();
+      QString configFile = QString("%1/perfolder-settings.conf").arg(settings.profileDir(settings.profileName()));
+      QSettings file(configFile, QSettings::IniFormat);
+      QHash<QString, QVariant> customFolders = file.value("customFolders").toHash();
+      FmPath* path = fm_folder_get_path(folder);
+      char* pathStr = fm_path_to_str(path);
+      QString folder(pathStr);
+      g_free(pathStr);
+      QHash<QString, QVariant> props = customFolders.value(folder).toHash();
+
+      if(!checked) {
+        if(props.contains("SortColumn"))
+        {
+          props.remove("Mode");
+          customFolders.insert(folder, props);
+        }
+        else
+          customFolders.remove(folder);
+        file.setValue("customFolders", customFolders);
+        if(page->viewMode() != settings.viewMode()) {
+          page->setViewMode(settings.viewMode());
+          switch(settings.viewMode()) { // there's no slot to set checkboxes
+          case Fm::FolderView::IconMode:
+          default:
+            ui.actionIconView->setChecked(true);
+            break;
+          case Fm::FolderView::CompactMode:
+            ui.actionCompactView->setChecked(true);
+            break;
+          case Fm::FolderView::DetailedListMode:
+            ui.actionDetailedList->setChecked(true);
+            break;
+          case Fm::FolderView::ThumbnailMode:
+            ui.actionThumbnailView->setChecked(true);
+            break;
+          }
+        }
+      }
+      else {
+        int viewMode;
+        switch(page->viewMode()) {
+          case Fm::FolderView::IconMode:
+          default:
+            viewMode = 0;
+            break;
+          case Fm::FolderView::CompactMode:
+            viewMode = 1;
+            break;
+          case Fm::FolderView::DetailedListMode:
+            viewMode = 2;
+            break;
+          case Fm::FolderView::ThumbnailMode:
+            viewMode = 3;
+            break;
+        }
+        props.insert("Mode", QVariant(viewMode));
+        customFolders.insert(folder, props);
+        file.setValue("customFolders", customFolders);
+      }
+    }
+  }
 }
 
 void MainWindow::onTabBarCloseRequested(int index) {
@@ -727,6 +886,27 @@ void MainWindow::updateViewMenuForCurrentPage() {
 
     ui.actionCaseSensitive->setChecked(tabPage->sortCaseSensitive());
     ui.actionFolderFirst->setChecked(tabPage->sortFolderFirst());
+
+    // see if this folder is customized
+    ui.actionPreserveSorting->setChecked(false);
+    ui.actionPreserveView->setChecked(false);
+    FmFolder* folder = tabPage->folder();
+    if(folder) {
+      Settings& settings = static_cast<Application*>(qApp)->settings();
+      QString configFile = QString("%1/perfolder-settings.conf").arg(settings.profileDir(settings.profileName()));
+      QSettings file(configFile, QSettings::IniFormat);
+      QHash<QString, QVariant> customFolders = file.value("customFolders").toHash();
+      FmPath* path = fm_folder_get_path(folder);
+      char* pathStr = fm_path_to_str(path);
+      QString folder(pathStr);
+      g_free(pathStr);
+      QHash<QString, QVariant> props = customFolders.value(folder).toHash();
+      if(props.isEmpty()) return;
+      if(props.contains("SortColumn"))
+        ui.actionPreserveSorting->setChecked(true);
+      if(props.contains("Mode"))
+        ui.actionPreserveView->setChecked(true);
+    }
   }
 }
 
@@ -748,6 +928,43 @@ void MainWindow::updateUIForCurrentPage() {
     ui.actionGoUp->setEnabled(tabPage->canUp());
     ui.actionGoBack->setEnabled(tabPage->canBackward());
     ui.actionGoForward->setEnabled(tabPage->canForward());
+
+    // update view mode when needed, considering customized folders
+    FmFolder* folder = tabPage->folder();
+    if(folder) {
+      Settings& settings = static_cast<Application*>(qApp)->settings();
+      QString configFile = QString("%1/perfolder-settings.conf").arg(settings.profileDir(settings.profileName()));
+      QSettings file(configFile, QSettings::IniFormat);
+      QHash<QString, QVariant> customFolders = file.value("customFolders").toHash();
+      FmPath* path = fm_folder_get_path(folder);
+      char* pathStr = fm_path_to_str(path);
+      QString folder(pathStr);
+      g_free(pathStr);
+      QHash<QString, QVariant> props = customFolders.value(folder).toHash();
+      if(props.contains("Mode")) {
+        int viewMode = props.value("Mode").toInt();
+        Fm::FolderView::ViewMode vm;
+        switch(viewMode) {
+          case 0:
+          default:
+            vm = Fm::FolderView::IconMode;
+            break;
+          case 1:
+            vm = Fm::FolderView::CompactMode;
+            break;
+          case 2:
+            vm = Fm::FolderView::DetailedListMode;
+            break;
+          case 3:
+            vm = Fm::FolderView::ThumbnailMode;
+            break;
+        }
+        if(tabPage->viewMode() != vm)
+          tabPage->setViewMode(vm);
+      }
+      else if (tabPage->viewMode() != settings.viewMode()) // always revert to the default mode
+        tabPage->setViewMode(settings.viewMode());
+    }
 
     updateViewMenuForCurrentPage();
     updateStatusBarForCurrentPage();
@@ -825,10 +1042,14 @@ void MainWindow::onTabPageSortFilterChanged() {
 
   if(tabPage == currentPage()) {
     updateViewMenuForCurrentPage();
-    Settings& settings = static_cast<Application*>(qApp)->settings();
-    settings.setSortColumn(static_cast<Fm::FolderModel::ColumnId>(tabPage->sortColumn()));
-    settings.setSortOrder(tabPage->sortOrder());
-    settings.setSortFolderFirst(tabPage->sortFolderFirst());
+    if(ui.actionPreserveSorting->isChecked())
+      on_actionPreserveSorting_triggered(true);
+    else {
+      Settings& settings = static_cast<Application*>(qApp)->settings();
+      settings.setSortColumn(static_cast<Fm::FolderModel::ColumnId>(tabPage->sortColumn()));
+      settings.setSortOrder(tabPage->sortOrder());
+      settings.setSortFolderFirst(tabPage->sortFolderFirst());
+    }
   }
 }
 

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -56,7 +56,8 @@ namespace PCManFM {
 MainWindow::MainWindow(Path path):
   QMainWindow(),
   fileLauncher_(this),
-  rightClickIndex(-1) {
+  rightClickIndex(-1),
+  updatingViewMenu_(false) {
 
   Settings& settings = static_cast<Application*>(qApp)->settings();
   setAttribute(Qt::WA_DeleteOnClose);
@@ -685,8 +686,10 @@ void MainWindow::updateStatusBarForCurrentPage() {
 }
 
 void MainWindow::updateViewMenuForCurrentPage() {
+  if(updatingViewMenu_)  // prevent recursive calls
+    return;
+  updatingViewMenu_ = true;
   TabPage* tabPage = currentPage();
-
   if(tabPage) {
     // update menus. FIXME: should we move this to another method?
     ui.actionShowHidden->setChecked(tabPage->showHidden());
@@ -729,10 +732,10 @@ void MainWindow::updateViewMenuForCurrentPage() {
       ui.actionAscending->setChecked(true);
     else
       ui.actionDescending->setChecked(true);
-
     ui.actionCaseSensitive->setChecked(tabPage->sortCaseSensitive());
     ui.actionFolderFirst->setChecked(tabPage->sortFolderFirst());
   }
+  updatingViewMenu_ = false;
 }
 
 void MainWindow::updateUIForCurrentPage() {
@@ -826,7 +829,6 @@ void MainWindow::onTabPageOpenDirRequested(FmPath* path, int target) {
 
 void MainWindow::onTabPageSortFilterChanged() {
   TabPage* tabPage = static_cast<TabPage*>(sender());
-
   if(tabPage == currentPage()) {
     updateViewMenuForCurrentPage();
     if(!tabPage->hasCustomizedView()) {

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -180,6 +180,7 @@ private:
   Fm::Bookmarks bookmarks;
   Launcher fileLauncher_;
   int rightClickIndex;
+  bool updatingViewMenu_;
 };
 
 }

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -88,6 +88,7 @@ protected Q_SLOTS:
   void on_actionCompactView_triggered();
   void on_actionDetailedList_triggered();
   void on_actionThumbnailView_triggered();
+  void on_actionPreserveView_triggered(bool checked);
 
   void on_actionGo_triggered();
   void on_actionShowHidden_triggered(bool check);
@@ -101,6 +102,7 @@ protected Q_SLOTS:
   void on_actionDescending_triggered(bool checked);
   void on_actionFolderFirst_triggered(bool checked);
   void on_actionCaseSensitive_triggered(bool checked);
+  void on_actionPreserveSorting_triggered(bool checked);
   void on_actionFilter_triggered(bool checked);
 
   void on_actionApplications_triggered();
@@ -171,6 +173,7 @@ private:
   void updateViewMenuForCurrentPage();
   void updateStatusBarForCurrentPage();
   void setRTLIcons(bool isRTL);
+  void saveViewMode();
 
 private:
   Ui::MainWindow ui;

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -88,10 +88,10 @@ protected Q_SLOTS:
   void on_actionCompactView_triggered();
   void on_actionDetailedList_triggered();
   void on_actionThumbnailView_triggered();
-  void on_actionPreserveView_triggered(bool checked);
 
   void on_actionGo_triggered();
   void on_actionShowHidden_triggered(bool check);
+  void on_actionPreserveView_triggered(bool checked);
 
   void on_actionByFileName_triggered(bool checked);
   void on_actionByMTime_triggered(bool checked);
@@ -102,7 +102,6 @@ protected Q_SLOTS:
   void on_actionDescending_triggered(bool checked);
   void on_actionFolderFirst_triggered(bool checked);
   void on_actionCaseSensitive_triggered(bool checked);
-  void on_actionPreserveSorting_triggered(bool checked);
   void on_actionFilter_triggered(bool checked);
 
   void on_actionApplications_triggered();
@@ -173,7 +172,6 @@ private:
   void updateViewMenuForCurrentPage();
   void updateStatusBarForCurrentPage();
   void setRTLIcons(bool isRTL);
-  void saveViewMode();
 
 private:
   Ui::MainWindow ui;

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -585,6 +585,7 @@ FolderSettings Settings::loadFolderSettings(Fm::Path path) const {
   settings.setSortColumn(sortColumn());
   settings.setViewMode(viewMode());
   settings.setShowHidden(showHidden());
+  settings.setSortFolderFirst(sortFolderFirst());
   settings.setSortCaseSensitive(sortCaseSensitive());
   // columns?
   if(!cfg.isEmpty()) {

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -26,6 +26,7 @@
 #include <QApplication>
 #include "desktopwindow.h"
 #include <libfm-qt/utilities.h>
+#include <libfm-qt/folderconfig.h>
 // #include <QDesktopServices>
 
 namespace PCManFM {
@@ -88,6 +89,7 @@ Settings::Settings():
   sortOrder_(Qt::AscendingOrder),
   sortColumn_(Fm::FolderModel::ColumnFileName),
   sortFolderFirst_(true),
+  sortCaseSensitive_(false),
   showFilter_(false),
   // settings for use with libfm
   singleClick_(false),
@@ -233,6 +235,7 @@ bool Settings::loadFile(QString filePath) {
   sortOrder_ = sortOrderFromString(settings.value("SortOrder").toString());
   sortColumn_ = sortColumnFromString(settings.value("SortColumn").toString());
   sortFolderFirst_ = settings.value("SortFolderFirst", true).toBool();
+  sortCaseSensitive_ = settings.value("SortCaseSensitive", false).toBool();
   showFilter_ = settings.value("ShowFilter", false).toBool();
 
   setBackupAsHidden(settings.value("BackupAsHidden", false).toBool());
@@ -342,6 +345,7 @@ bool Settings::saveFile(QString filePath) {
   settings.setValue("SortOrder", sortOrderToString(sortOrder_));
   settings.setValue("SortColumn", sortColumnToString(sortColumn_));
   settings.setValue("SortFolderFirst", sortFolderFirst_);
+  settings.setValue("SortCaseSensitive", sortCaseSensitive_);
   settings.setValue("ShowFilter", showFilter_);
 
   settings.setValue("BackupAsHidden", backupAsHidden_);
@@ -381,6 +385,10 @@ bool Settings::saveFile(QString filePath) {
   settings.setValue("ShowMenuBar", showMenuBar_);
   settings.setValue("FullWidthTabBar", fullWidthTabBar_);
   settings.endGroup();
+
+  // save per-folder settings
+  Fm::FolderConfig::saveCache();
+
   return true;
 }
 
@@ -565,6 +573,80 @@ void Settings::setTerminal(QString terminalCommand) {
     g_free(fm_config->terminal);
     fm_config->terminal = g_strdup(terminal_.toLocal8Bit().constData());
     g_signal_emit_by_name(fm_config, "changed::terminal");
+}
+
+
+// per-folder settings
+FolderSettings Settings::loadFolderSettings(Fm::Path path) const {
+  FolderSettings settings;
+  Fm::FolderConfig cfg(path);
+  // set defaults
+  settings.setSortOrder(sortOrder());
+  settings.setSortColumn(sortColumn());
+  settings.setViewMode(viewMode());
+  settings.setShowHidden(showHidden());
+  settings.setSortCaseSensitive(sortCaseSensitive());
+  // columns?
+  if(!cfg.isEmpty()) {
+    // load folder-specific settings
+    settings.setCustomized(true);
+
+    char* str;
+    // load sorting
+    str = cfg.getString("SortOrder");
+    if(str != nullptr) {
+      settings.setSortOrder(sortOrderFromString(str));
+      g_free(str);
+    }
+
+    str = cfg.getString("SortColumn");
+    if(str != nullptr) {
+      settings.setSortColumn(sortColumnFromString(str));
+      g_free(str);
+    }
+
+    str = cfg.getString("ViewMode");
+    if(str != nullptr) {
+      // set view mode
+      settings.setViewMode(viewModeFromString(str));
+      g_free(str);
+    }
+
+    gboolean show_hidden;
+    if(cfg.getBoolean("ShowHidden", &show_hidden)) {
+      settings.setShowHidden(show_hidden);
+    }
+
+    gboolean folder_first;
+    if(cfg.getBoolean("SortFolderFirst", &folder_first)) {
+      settings.setSortFolderFirst(folder_first);
+    }
+
+    gboolean case_sensitive;
+    if(cfg.getBoolean("SortCaseSensitive", &case_sensitive)) {
+      settings.setSortCaseSensitive(case_sensitive);
+    }
+  }
+  return settings;
+}
+
+void Settings::saveFolderSettings(Fm::Path path, const FolderSettings& settings) {
+  if(!path.isNull()) {
+    Fm::FolderConfig cfg(path);
+    cfg.setString("SortOrder", sortOrderToString(settings.sortOrder()));
+    cfg.setString("SortColumn", sortColumnToString(settings.sortColumn()));
+    cfg.setString("ViewMode", viewModeToString(settings.viewMode()));
+    cfg.setBoolean("ShowHidden", settings.showHidden());
+    cfg.setBoolean("SortFolderFirst", settings.sortFolderFirst());
+    cfg.setBoolean("SortCaseSensitive", settings.sortCaseSensitive());
+  }
+}
+
+void Settings::clearFolderSettings(Fm::Path path) const {
+  if(!path.isNull()) {
+    Fm::FolderConfig cfg(path);
+    cfg.purge();
+  }
 }
 
 

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -130,6 +130,8 @@ public:
   bool loadFile(QString filePath);
   bool saveFile(QString filePath);
 
+  static QString xdgUserConfigDir();
+
   QString profileDir(QString profile, bool useFallback = false);
 
   // setter/getter functions

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -38,6 +38,85 @@ enum OpenDirTargetType {
     OpenInLastActiveWindow
 };
 
+class FolderSettings {
+public:
+  FolderSettings():
+    isCustomized_(false),
+    sortOrder_(Qt::AscendingOrder),
+    sortColumn_(Fm::FolderModel::ColumnFileName),
+    viewMode_(Fm::FolderView::IconMode),
+    showHidden_(false),
+    sortCaseSensitive_(true) {
+  }
+
+  bool isCustomized() const {
+    return isCustomized_;
+  }
+
+  void setCustomized(bool value) {
+    isCustomized_ = value;
+  }
+
+  Qt::SortOrder sortOrder() const {
+    return sortOrder_;
+  }
+
+  void setSortOrder(Qt::SortOrder value) {
+    sortOrder_ = value;
+  }
+
+  Fm::FolderModel::ColumnId sortColumn() const {
+    return sortColumn_;
+  }
+
+  void setSortColumn(Fm::FolderModel::ColumnId value) {
+    sortColumn_ = value;
+  }
+
+  Fm::FolderView::ViewMode viewMode() const {
+    return viewMode_;
+  }
+
+  void setViewMode(Fm::FolderView::ViewMode value) {
+    viewMode_ = value;
+  }
+
+  bool sortFolderFirst() const {
+    return sortFolderFirst_;
+  }
+
+  void setSortFolderFirst(bool value) {
+    sortFolderFirst_ = value;
+  }
+
+  bool showHidden() const {
+    return showHidden_;
+  }
+
+  void setShowHidden(bool value) {
+    showHidden_ = value;
+  }
+
+  bool sortCaseSensitive() const {
+    return sortCaseSensitive_;
+  }
+
+  void setSortCaseSensitive(bool value) {
+    sortCaseSensitive_ = value;
+  }
+
+private:
+  bool isCustomized_;
+  Qt::SortOrder sortOrder_;
+  Fm::FolderModel::ColumnId sortColumn_;
+  Fm::FolderView::ViewMode viewMode_;
+  bool sortFolderFirst_;
+  bool showHidden_;
+  bool sortCaseSensitive_;
+  // columns?
+};
+
+
 class Settings : public QObject {
   Q_OBJECT
 public:
@@ -354,6 +433,15 @@ public:
     showHidden_ = showHidden;
   }
 
+  bool sortCaseSensitive() const {
+    return sortCaseSensitive_;
+  }
+
+  void setSortCaseSensitive(bool value) {
+    sortCaseSensitive_ = value;
+  }
+
+
   bool placesHome() const {
       return placesHome_;
   }
@@ -642,6 +730,12 @@ public:
     fm_config->template_run_app = templateRunApp_;
   }
 
+  // per-folder settings
+  FolderSettings loadFolderSettings(Fm::Path path) const;
+
+  void saveFolderSettings(Fm::Path path, const FolderSettings &settings);
+
+  void clearFolderSettings(Fm::Path path) const;
 
 private:
   QString profileName_;
@@ -691,6 +785,7 @@ private:
   Qt::SortOrder sortOrder_;
   Fm::FolderModel::ColumnId sortColumn_;
   bool sortFolderFirst_;
+  bool sortCaseSensitive_;
   bool showFilter_;
 
   // settings for use with libfm

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -46,6 +46,7 @@ public:
     sortColumn_(Fm::FolderModel::ColumnFileName),
     viewMode_(Fm::FolderView::IconMode),
     showHidden_(false),
+    sortFolderFirst_(true),
     sortCaseSensitive_(true) {
   }
 
@@ -110,8 +111,8 @@ private:
   Qt::SortOrder sortOrder_;
   Fm::FolderModel::ColumnId sortColumn_;
   Fm::FolderView::ViewMode viewMode_;
-  bool sortFolderFirst_;
   bool showHidden_;
+  bool sortFolderFirst_;
   bool sortCaseSensitive_;
   // columns?
 };

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -33,6 +33,7 @@
 #include "application.h"
 #include <QTimer>
 #include <QTextStream>
+#include <QSettings>
 
 using namespace Fm;
 
@@ -385,9 +386,45 @@ void TabPage::chdir(Path newPath, bool addHistory) {
   folderModel_ = CachedFolderModel::modelFromFolder(folder_);
   proxyModel_->setSourceModel(folderModel_);
   proxyModel_->sort(proxyModel_->sortColumn(), proxyModel_->sortOrder());
+  // set sorting, considering customized folders
   Settings& settings = static_cast<Application*>(qApp)->settings();
-  proxyModel_->setFolderFirst(settings.sortFolderFirst());
-  proxyModel_->sort(settings.sortColumn(), settings.sortOrder());
+  QString configFile = QString("%1/perfolder-settings.conf").arg(settings.profileDir(settings.profileName()));
+  QSettings file(configFile, QSettings::IniFormat);
+  // we use a nested QHash<QString(folder), QHash<QString(property), QVariant(value)>> in "mainwindow.cpp"
+  QHash<QString, QVariant> customFolders = file.value("customFolders").toHash();
+  char* pathStr = fm_path_to_str(path());
+  QString folder(pathStr);
+  g_free(pathStr);
+  QHash<QString, QVariant> props = customFolders.value(folder).toHash();
+  if(props.contains("SortColumn")) {
+    Fm::FolderModel::ColumnId sortColumn;
+    int columnId = props.value("SortColumn").toInt();
+    switch(columnId) {
+      case 0:
+      default:
+        sortColumn = Fm::FolderModel::ColumnFileName;
+        break;
+      case 1:
+        sortColumn = Fm::FolderModel::ColumnFileType;
+        break;
+      case 2:
+        sortColumn = Fm::FolderModel::ColumnFileSize;
+        break;
+      case 3:
+        sortColumn = Fm::FolderModel::ColumnFileMTime;
+        break;
+      case 4:
+        sortColumn = Fm::FolderModel::ColumnFileOwner;
+        break;
+    }
+    proxyModel_->sort(sortColumn,
+                      props.value("SortOrder").toInt() == 0 ? Qt::AscendingOrder : Qt::DescendingOrder);
+    proxyModel_->setFolderFirst(props.value("SortFolderFirst").toBool());
+  }
+  else { // always revert to the default sorting
+    proxyModel_->setFolderFirst(settings.sortFolderFirst());
+    proxyModel_->sort(settings.sortColumn(), settings.sortOrder());
+  }
 
   if(folder_.isLoaded()) {
     onFolderStartLoading(folder_, this);

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -215,7 +215,6 @@ Q_SIGNALS:
 
 protected Q_SLOTS:
   void onOpenDirRequested(FmPath* path, int target);
-  void onModelSortFilterChanged();
   void onSelChanged(int numSel);
   void restoreScrollPos();
 

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -29,6 +29,7 @@
 #include <libfm-qt/path.h>
 #include <libfm-qt/folder.h>
 #include <libfm-qt/fileinfo.h>
+#include "settings.h"
 
 namespace Fm {
   class FileLauncher;
@@ -39,7 +40,6 @@ namespace Fm {
 
 namespace PCManFM {
 
-class Settings;
 class Launcher;
 
 class ProxyFilter : public Fm::ProxyFolderModelFilter {
@@ -77,44 +77,34 @@ public:
   void chdir(Fm::Path newPath, bool addHistory = true);
 
   Fm::FolderView::ViewMode viewMode() {
-    return folderView_->viewMode();
+    return folderSettings_.viewMode();
   }
 
-  void setViewMode(Fm::FolderView::ViewMode mode) {
-    folderView_->setViewMode(mode);
-  }
+  void setViewMode(Fm::FolderView::ViewMode mode);
 
-  void sort(int col, Qt::SortOrder order = Qt::AscendingOrder) {
-    // if(folderModel_)
-    //  folderModel_->sort(col, order);
-    if(proxyModel_)
-      proxyModel_->sort(col, order);
-  }
+  void sort(int col, Qt::SortOrder order = Qt::AscendingOrder);
 
   int sortColumn() {
-    return proxyModel_->sortColumn();
+    return folderSettings_.sortColumn();
   }
 
   Qt::SortOrder sortOrder() {
-    return proxyModel_->sortOrder();
+    return folderSettings_.sortOrder();
   }
 
   bool sortFolderFirst() {
-    return proxyModel_->folderFirst();
+    return folderSettings_.sortFolderFirst();
   }
-  void setSortFolderFirst(bool value) {
-    proxyModel_->setFolderFirst(value);
-  }
+  void setSortFolderFirst(bool value);
 
   bool sortCaseSensitive() {
-    return proxyModel_->sortCaseSensitivity();
-  }
-  void setSortCaseSensitive(bool value) {
-    proxyModel_->setSortCaseSensitivity(value ? Qt::CaseSensitive : Qt::CaseInsensitive);
+    return folderSettings_.sortCaseSensitive();
   }
 
+  void setSortCaseSensitive(bool value);
+
   bool showHidden() {
-    return proxyModel_->showHidden();
+    return folderSettings_.showHidden();
   }
 
   void setShowHidden(bool showHidden);
@@ -209,6 +199,12 @@ public:
 
   void applyFilter();
 
+  bool hasCustomizedView() {
+    return folderSettings_.isCustomized();
+  }
+
+  void setCustomizedView(bool value);
+
 Q_SIGNALS:
   void statusChanged(int type, QString statusText);
   void titleChanged(QString title);
@@ -247,6 +243,7 @@ private:
   Fm::BrowseHistory history_; // browsing history
   Fm::Path lastFolderPath_; // last browsed folder
   bool overrideCursor_;
+  FolderSettings folderSettings_;
 };
 
 }


### PR DESCRIPTION
This new implementation supersedes the old PR #343 with the following changes.

1. Encapsulation with PCManFM::FolderSettings class and move most of the handling into PCManFM::TabPage rather than adding duplicated pieces of code in MainWindow.
2. Remove the code in onAboutToQuit since it does not work. For example, folders on removable devices  or remote filesystems might have their folder temporarily unavailable, but their per-folder settings should not be deleted.
3. Do not distinguish between per-folder sort settings and per-folder view settings. Separating them is too fine-grained and makes the code complicated. The gtk+ version of pcmanfm uses only one option to control them and this works well enough.
4. Re-use Fm::FolderConfig internally to store the settings.
5. Remove tear-down menus which is an out-dated UI style inconsistent with the rest parts of the DE.
6. Do not change the default view mode when you change the view mode of the current tab. This is a "feature", not a bug. The default view mode is configured in the preferences dialog.

@tsujan I merged your code last week, but after some more code review I found some issues listed above. So later I decided to do some refactor and rewrites.