### PR TITLE
wallpaper: Add helper logic for LXQt

### DIFF
--- a/pcmanfm/application.h
+++ b/pcmanfm/application.h
@@ -70,7 +70,7 @@ public:
 
   // public interface exported via dbus
   void launchFiles(QString cwd, QStringList paths, bool inNewWindow);
-  void setWallpaper(QString path, QString modeString);
+  void setWallpaper(QString path, QString modeString, bool byLXQtTheme);
   void preferences(QString page);
   void desktopPrefrences(QString page);
   void editBookmarks();
@@ -83,6 +83,12 @@ public:
 
   void updateFromSettings();
   void updateDesktopsFromSettings();
+  /*! \brief Sets wallpaperChanged into LXQt settings
+   * ($XDG_CONFIG_HOME/lxqt/lxqt.conf). This is a helper config value for
+   * lxqt-config-appearance to distinguish if user changed the wallpeper
+   * independently on theme.
+   */
+  void setWallpaperLXQtSetting() const;
 
   void openFolderInTerminal(Fm::Path path);
   void openFolders(Fm::FileInfoList files);

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -30,6 +30,7 @@
 #include <QRegExp>
 #include <QDebug>
 #include <QStandardPaths>
+#include <QSettings>
 
 namespace PCManFM {
 
@@ -138,6 +139,9 @@ void DesktopPreferencesDialog::applySettings()
   if (editDesktopFolderEnabled)
       XdgDir::setDesktopDir(uiDesktopFolder.desktopFolder->text());
 
+  // Note: LXQt helper
+  if (settings.wallpaper() != ui.imageFile->text())
+      static_cast<Application const * const>(qApp)->setWallpaperLXQtSetting();
   settings.setWallpaper(ui.imageFile->text());
   int mode = ui.wallpaperMode->itemData(ui.wallpaperMode->currentIndex()).toInt();
   settings.setWallpaperMode(mode);

--- a/pcmanfm/org.pcmanfm.Application.xml
+++ b/pcmanfm/org.pcmanfm.Application.xml
@@ -20,6 +20,7 @@
     <method name="setWallpaper">
       <arg type="s" direction="in"/>
       <arg type="s" direction="in"/>
+      <arg type="b" direction="in"/>
     </method>
     <method name="findFiles">
       <arg type="as" direction="in"/>


### PR DESCRIPTION
Store "wallpaperChanged" value into LXQt config
($XDG_CONFIG_HOME/lxqt/lxqt.conf) if wallpaper was not changed by LXQt
theme.

With this help the lxqt-config-appearance can do the decision to (not)
change the wallpaper when changing the LXQt theme.


Needed by lxde/lxqt-config#99