### PR TITLE
Add Pathbar Separator

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -277,8 +277,8 @@
    <addaction name="actionGoForward"/>
    <addaction name="actionGoUp"/>
    <addaction name="actionReload"/>
-   <addaction name="actionGo"/>
    <addaction name="separator"/>
+   <addaction name="actionGo"/>
    <addaction name="actionMenu"/>
   </widget>
   <action name="actionGoUp">

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -203,10 +203,8 @@ MainWindow::MainWindow(Path path):
   QToolButton* menuBtn = static_cast<QToolButton*>(ui.toolBar->widgetForAction(ui.actionMenu));
   menuBtn->setPopupMode(QToolButton::InstantPopup);
 
-  Q_FOREACH(QAction *action, ui.toolBar->actions()) {
-    if(action->isSeparator())
-      action->setVisible(!settings.showMenuBar());
-  }
+  menuSep_ = ui.toolBar->insertSeparator(ui.actionMenu);
+  menuSep_->setVisible(!settings.showMenuBar());
   ui.actionMenu->setVisible(!settings.showMenuBar());
   ui.menubar->setVisible(settings.showMenuBar());
   ui.actionMenu_bar->setChecked(settings.showMenuBar());
@@ -351,10 +349,7 @@ void MainWindow::toggleMenuBar(bool checked) {
 
   ui.menubar->setVisible(showMenuBar);
   ui.actionMenu_bar->setChecked(showMenuBar);
-  Q_FOREACH(QAction *action, ui.toolBar->actions()) {
-    if(action->isSeparator())
-      action->setVisible(!showMenuBar);
-  }
+  menuSep_->setVisible(!showMenuBar);
   ui.actionMenu->setVisible(!showMenuBar);
   settings.setShowMenuBar(showMenuBar);
 }

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -198,6 +198,7 @@ private:
   Launcher fileLauncher_;
   int rightClickIndex_;
   bool updatingViewMenu_;
+  QAction* menuSep_;
 
   static MainWindow* lastActive_;
 };


### PR DESCRIPTION
Now that pathbar can have toolbuttons, a separator is needed before it. The separator is especially needed with style engines that can group toolbar buttons (like QtCurve and Kvantum).

A screenshot with Kvantum:
![pathbar_sep](https://cloud.githubusercontent.com/assets/981076/20860783/f89b5566-b995-11e6-9c16-d17ccebfb79e.png)
