### PR TITLE
Make dialogue "About" point out it's the Qt version of PCManFM

### DIFF
--- a/pcmanfm/about.ui
+++ b/pcmanfm/about.ui
@@ -22,7 +22,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:16pt; font-weight:600;&quot;&gt;PCManFM&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:16pt; font-weight:600;&quot;&gt;PCManFM-Qt&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>
@@ -106,7 +106,7 @@
           <bool>true</bool>
          </property>
          <property name="plainText">
-          <string>PCMan File Manager
+          <string>PCManFM-Qt File Manager
 
 Copyright (C) 2009 - 2014 洪任諭 (Hong Jen Yee)
 


### PR DESCRIPTION
So far the dialogue is only stating "PCManFM" which may trick users into thinking the GTK version was running. Happened to crop up some days on the tracker as well, see #417.

So this PR is simply proposing to state "PCManFM-Qt" in order to avoid such confusion.