### PR TITLE
Prevent wrong clearing of filter-bar with path buttons

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -370,7 +370,11 @@ void MainWindow::onPathEntryEdited(const QString& text) {
 }
 
 void MainWindow::onPathBarChdir(FmPath* dirPath) {
-  chdir(dirPath);
+  // call chdir() only when needed because otherwise
+  // filter bar will be cleard on changing current tab
+  TabPage* page = currentPage();
+  if(page && dirPath != page->path())
+    chdir(dirPath);
 }
 
 void MainWindow::onPathBarMiddleClickChdir(FmPath* dirPath) {


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/431.

With path buttons, filter-bar was cleared on changing the current tab because libfm-qt uses `QPushButton::toggled` as the signal and so, `MainWindow::chdir()` was always called when path buttons changed their toggled state. This patch prevents redundant calls to `MainWindow::chdir()`.