### PR TITLE
Tab detachment and DND

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -31,6 +31,7 @@
 #include <QKeySequence>
 #include <QDir>
 #include <QSettings>
+#include <QMimeData>
 #include <QDebug>
 
 #include "tabpage.h"
@@ -114,6 +115,7 @@ MainWindow::MainWindow(Path path):
   connect(ui.tabBar, &QTabBar::tabCloseRequested, this, &MainWindow::onTabBarCloseRequested);
   connect(ui.tabBar, &QTabBar::tabMoved, this, &MainWindow::onTabBarTabMoved);
   connect(ui.tabBar, &QTabBar::customContextMenuRequested, this, &MainWindow::tabContextMenu);
+  connect(ui.tabBar, &TabBar::tabDetached, this, &MainWindow::detachTab);
   connect(ui.stackedWidget, &QStackedWidget::widgetRemoved, this, &MainWindow::onStackedWidgetWidgetRemoved);
 
   // FIXME: should we make the filter bar a per-view configuration?
@@ -268,14 +270,16 @@ MainWindow::MainWindow(Path path):
     addTab(path);
 
   // size from settings
-  if(settings.rememberWindowSize()) {
-    resize(settings.windowWidth(), settings.windowHeight());
-    if(settings.windowMaximized())
-      setWindowState(windowState() | Qt::WindowMaximized);
+  resize(settings.windowWidth(), settings.windowHeight());
+  if(settings.rememberWindowSize() && settings.windowMaximized()) {
+    setWindowState(windowState() | Qt::WindowMaximized);
   }
 
   if(QApplication::layoutDirection() == Qt::RightToLeft)
     setRTLIcons(true);
+
+  // we want tab dnd
+  setAcceptDrops(true);
 }
 
 MainWindow::~MainWindow() {
@@ -311,27 +315,32 @@ void MainWindow::createPathBar(bool usePathButtons) {
   ui.actionGo->setVisible(!usePathButtons);
 }
 
-// add a new tab
-int MainWindow::addTab(Path path) {
+int MainWindow::addTabWithPage(TabPage* page) {
+  if(page == nullptr)
+    return -1;
+  page->setFileLauncher(&fileLauncher_);
+  int index = ui.stackedWidget->addWidget(page);
+  connect(page, &TabPage::titleChanged, this, &MainWindow::onTabPageTitleChanged);
+  connect(page, &TabPage::statusChanged, this, &MainWindow::onTabPageStatusChanged);
+  connect(page, &TabPage::openDirRequested, this, &MainWindow::onTabPageOpenDirRequested);
+  connect(page, &TabPage::sortFilterChanged, this, &MainWindow::onTabPageSortFilterChanged);
+  connect(page, &TabPage::backwardRequested, this, &MainWindow::on_actionGoBack_triggered);
+  connect(page, &TabPage::forwardRequested, this, &MainWindow::on_actionGoForward_triggered);
+
+  ui.tabBar->insertTab(index, page->title());
+
   Settings& settings = static_cast<Application*>(qApp)->settings();
-
-  TabPage* newPage = new TabPage(path, this);
-  newPage->setFileLauncher(&fileLauncher_);
-  int index = ui.stackedWidget->addWidget(newPage);
-  connect(newPage, &TabPage::titleChanged, this, &MainWindow::onTabPageTitleChanged);
-  connect(newPage, &TabPage::statusChanged, this, &MainWindow::onTabPageStatusChanged);
-  connect(newPage, &TabPage::openDirRequested, this, &MainWindow::onTabPageOpenDirRequested);
-  connect(newPage, &TabPage::sortFilterChanged, this, &MainWindow::onTabPageSortFilterChanged);
-  connect(newPage, &TabPage::backwardRequested, this, &MainWindow::on_actionGoBack_triggered);
-  connect(newPage, &TabPage::forwardRequested, this, &MainWindow::on_actionGoForward_triggered);
-
-  ui.tabBar->insertTab(index, newPage->title());
-
   if(!settings.alwaysShowTabs()) {
     ui.tabBar->setVisible(ui.tabBar->count() > 1);
   }
 
   return index;
+}
+
+// add a new tab
+int MainWindow::addTab(Path path) {
+  TabPage* newPage = new TabPage(path, this);
+  return addTabWithPage(newPage);
 }
 
 void MainWindow::toggleMenuBar(bool checked) {
@@ -1167,6 +1176,76 @@ void MainWindow::focusPathEntry() {
   else if (pathBar_ != nullptr) { // use button-style path bar
     pathBar_->openEditor();
   }
+}
+
+void MainWindow::dragEnterEvent(QDragEnterEvent *event) {
+  if(event->mimeData()->hasFormat("application/pcmanfm-qt-tab"))
+    event->acceptProposedAction();
+}
+
+void MainWindow::dropEvent(QDropEvent *event) {
+  if(event->mimeData()->hasFormat("application/pcmanfm-qt-tab"))
+    dropTab();
+  event->acceptProposedAction();
+}
+
+void MainWindow::dropTab() {
+  if(lastActive_ == nullptr // impossible
+     || lastActive_ == this) { // don't drop on the same window
+    ui.tabBar->finishMouseMoveEvent();
+    return;
+  }
+
+  // close the tab in the first window and add
+  // its page to a new tab in the second window
+  TabPage* dropPage = lastActive_->currentPage();
+  if(dropPage) {
+    disconnect(dropPage, &TabPage::titleChanged, lastActive_, &MainWindow::onTabPageTitleChanged);
+    disconnect(dropPage, &TabPage::statusChanged, lastActive_, &MainWindow::onTabPageStatusChanged);
+    disconnect(dropPage, &TabPage::openDirRequested, lastActive_, &MainWindow::onTabPageOpenDirRequested);
+    disconnect(dropPage, &TabPage::sortFilterChanged, lastActive_, &MainWindow::onTabPageSortFilterChanged);
+    disconnect(dropPage, &TabPage::backwardRequested, lastActive_, &MainWindow::on_actionGoBack_triggered);
+    disconnect(dropPage, &TabPage::forwardRequested, lastActive_, &MainWindow::on_actionGoForward_triggered);
+
+    // release mouse before tab removal because otherwise, the source tabbar
+    // might not be updated properly with tab reordering during a fast drag-and-drop
+    lastActive_->ui.tabBar->releaseMouse();
+
+    QWidget* page = lastActive_->ui.stackedWidget->currentWidget();
+    lastActive_->ui.stackedWidget->removeWidget(page);
+    int index = addTabWithPage(dropPage);
+    ui.tabBar->setCurrentIndex(index);
+  }
+  else
+    ui.tabBar->finishMouseMoveEvent(); // impossible
+}
+
+void MainWindow::detachTab() {
+  if (ui.stackedWidget->count() == 1) { // don't detach a single tab
+    ui.tabBar->finishMouseMoveEvent();
+    return;
+  }
+
+  // close the tab and move its page to a new window
+  TabPage* dropPage = currentPage();
+  if(dropPage) {
+    disconnect(dropPage, &TabPage::titleChanged, this, &MainWindow::onTabPageTitleChanged);
+    disconnect(dropPage, &TabPage::statusChanged, this, &MainWindow::onTabPageStatusChanged);
+    disconnect(dropPage, &TabPage::openDirRequested, this, &MainWindow::onTabPageOpenDirRequested);
+    disconnect(dropPage, &TabPage::sortFilterChanged, this, &MainWindow::onTabPageSortFilterChanged);
+    disconnect(dropPage, &TabPage::backwardRequested, this, &MainWindow::on_actionGoBack_triggered);
+    disconnect(dropPage, &TabPage::forwardRequested, this, &MainWindow::on_actionGoForward_triggered);
+
+    ui.tabBar->releaseMouse(); // as in dropTab()
+
+    QWidget* page = ui.stackedWidget->currentWidget();
+    ui.stackedWidget->removeWidget(page);
+    MainWindow* newWin = new MainWindow();
+    newWin->addTabWithPage(dropPage);
+    newWin->show();
+  }
+  else
+    ui.tabBar->finishMouseMoveEvent(); // impossible
 }
 
 void MainWindow::updateFromSettings(Settings& settings) {

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -173,6 +173,7 @@ protected Q_SLOTS:
   }
   void focusPathEntry();
   void toggleMenuBar(bool checked);
+  void detachTab();
 
 protected:
   bool event(QEvent* event) override;
@@ -180,6 +181,8 @@ protected:
   void closeTab(int index);
   virtual void resizeEvent(QResizeEvent *event) override;
   virtual void closeEvent(QCloseEvent *event) override;
+  virtual void dragEnterEvent(QDragEnterEvent *event);
+  virtual void dropEvent(QDropEvent *event);
 
 private:
   static void onBookmarksChanged(FmBookmarks* bookmarks_, MainWindow* pThis);
@@ -189,6 +192,8 @@ private:
   void updateStatusBarForCurrentPage();
   void setRTLIcons(bool isRTL);
   void createPathBar(bool usePathButtons);
+  int addTabWithPage(TabPage* page);
+  void dropTab();
 
 private:
   Ui::MainWindow ui;

--- a/pcmanfm/tabbar.cpp
+++ b/pcmanfm/tabbar.cpp
@@ -19,13 +19,69 @@
 
 
 #include "tabbar.h"
+#include <QPointer>
 #include <QMouseEvent>
+#include <QApplication>
+#include <QDrag>
+#include <QMimeData>
 
 namespace PCManFM {
 
 TabBar::TabBar(QWidget *parent):
   QTabBar(parent)
 {
+}
+
+void TabBar::mousePressEvent(QMouseEvent *event) {
+  QTabBar::mousePressEvent (event);
+  if(event->button() == Qt::LeftButton
+     && tabAt(event->pos()) > -1) {
+    dragStartPosition_ = event->pos();
+  }
+  dragStarted_ = false;
+}
+
+void TabBar::mouseMoveEvent(QMouseEvent *event)
+{
+  if(!dragStartPosition_.isNull()
+     && (event->pos() - dragStartPosition_).manhattanLength() < QApplication::startDragDistance()) {
+    dragStarted_ = true;
+  }
+
+  if((event->buttons() & Qt::LeftButton)
+     && dragStarted_
+     && !window()->geometry().contains(event->globalPos())) {
+    if(currentIndex() == -1)
+      return;
+
+    QPointer<QDrag> drag = new QDrag(this);
+    QMimeData *mimeData = new QMimeData;
+    mimeData->setData("application/pcmanfm-qt-tab", QByteArray());
+    drag->setMimeData(mimeData);
+    Qt::DropAction dragged = drag->exec();
+    if(dragged == Qt::IgnoreAction) { // a tab is dropped outside all windows
+      if(count() > 1)
+        Q_EMIT tabDetached();
+      else
+        finishMouseMoveEvent();
+      event->accept();
+    }
+    else if(dragged == Qt::MoveAction) // a tab is dropped into another window
+      event->accept();
+    drag->deleteLater();
+  }
+  else
+    QTabBar::mouseMoveEvent(event);
+}
+
+void TabBar::finishMouseMoveEvent() {
+  QMouseEvent finishingEvent(QEvent::MouseMove, QPoint(), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+  mouseMoveEvent(&finishingEvent);
+}
+
+void TabBar::releaseMouse() {
+  QMouseEvent releasingEvent(QEvent::MouseButtonRelease, QPoint(), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+  mouseReleaseEvent(&releasingEvent);
 }
 
 void TabBar::mouseReleaseEvent(QMouseEvent *event) {
@@ -36,6 +92,12 @@ void TabBar::mouseReleaseEvent(QMouseEvent *event) {
     }
   }
   QTabBar::mouseReleaseEvent(event);
+}
+
+// Let the main window receive dragged tabs!
+void TabBar::dragEnterEvent(QDragEnterEvent *event) {
+  if(event->mimeData()->hasFormat("application/pcmanfm-qt-tab"))
+    event->ignore();
 }
 
 }

--- a/pcmanfm/tabbar.h
+++ b/pcmanfm/tabbar.h
@@ -32,9 +32,22 @@ Q_OBJECT
 
 public:
   explicit TabBar(QWidget *parent = 0);
+  void finishMouseMoveEvent();
+  void releaseMouse();
+
+Q_SIGNALS:
+  void tabDetached();
 
 protected:
-	void mouseReleaseEvent(QMouseEvent *event);
+  void mouseReleaseEvent(QMouseEvent *event);
+  /* from qtabbar.cpp */
+  virtual void mousePressEvent(QMouseEvent *event);
+  virtual void mouseMoveEvent(QMouseEvent *event);
+  virtual void dragEnterEvent(QDragEnterEvent *event);
+
+private:
+  QPoint dragStartPosition_;
+  bool dragStarted_;
 };
 
 }


### PR DESCRIPTION
This is about https://github.com/lxde/pcmanfm-qt/issues/428. IMO, users will find various applications for tab DND, as I did.

Tabs can be detached and also moved to another window by drag-and-drop. The page of the dropped tab is moved from the first window to the second one as a new tab without being deleted/recreated.