### PR TITLE
Add a workaround for the Qt5 bug which causes broken wallpaper background

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -119,6 +119,7 @@ protected Q_SLOTS:
 
 private:
   void removeBottomGap();
+  void paintBackground(QPaintEvent* event);
 
 private:
   Fm::ProxyFolderModel* proxyModel_;


### PR DESCRIPTION
This is to workaround Qt bug 54384 which affects Qt >= 5.6
https://bugreports.qt.io/browse/QTBUG-54384
Setting a QPixmap larger then the screen resolution to the background of a list view won't work.
So we did a hack here: Disable the automatic background painting.
Then paint the background of the list view ourselves by hook into its paint event handling method with a event filter.
Since this is a "hack", it's better to do more test to ensure it does not cause side effects. I really need helps on this. @tsujan please help test this if you have time since you're good at finding bugs. :-)