### PR TITLE
Inline Renaming for Desktop

### DIFF
--- a/pcmanfm/desktopitemdelegate.cpp
+++ b/pcmanfm/desktopitemdelegate.cpp
@@ -235,7 +235,9 @@ void DesktopItemDelegate::setEditorData(QWidget *editor, const QModelIndex &inde
     return;
   const QString currentName = index.data(Qt::EditRole).toString();
   textEdit->setPlainText(currentName);
+  textEdit->setUndoRedoEnabled(false);
   textEdit->setAlignment(Qt::AlignCenter);
+  textEdit->setUndoRedoEnabled(true);
   // select text appropriately
   QTextCursor cur = textEdit->textCursor();
   int end;

--- a/pcmanfm/desktopitemdelegate.cpp
+++ b/pcmanfm/desktopitemdelegate.cpp
@@ -213,6 +213,12 @@ QWidget* DesktopItemDelegate::createEditor(QWidget *parent, const QStyleOptionVi
   // we use QTextEdit instead of QPlainTextEdit because
   // the latter always shows an empty space at the bottom
   QTextEdit *textEdit = new QTextEdit(parent);
+  // Since the text color in inherited from the desktop foreground color,
+  // it may not be suitable. So, we reset it by using the app palette.
+  QPalette p = textEdit->palette();
+  p.setColor(QPalette::Text, qApp->palette().text().color());
+  textEdit->setPalette(p);
+
   textEdit->ensureCursorVisible();
   textEdit->setFocusPolicy(Qt::StrongFocus);
   textEdit->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/pcmanfm/desktopitemdelegate.cpp
+++ b/pcmanfm/desktopitemdelegate.cpp
@@ -213,7 +213,8 @@ QWidget* DesktopItemDelegate::createEditor(QWidget *parent, const QStyleOptionVi
   // we use QTextEdit instead of QPlainTextEdit because
   // the latter always shows an empty space at the bottom
   QTextEdit *textEdit = new QTextEdit(parent);
-  // Since the text color in inherited from the desktop foreground color,
+  textEdit->setAcceptRichText(false);
+  // Since the text color is inherited from the desktop foreground color,
   // it may not be suitable. So, we reset it by using the app palette.
   QPalette p = textEdit->palette();
   p.setColor(QPalette::Text, qApp->palette().text().color());

--- a/pcmanfm/desktopitemdelegate.h
+++ b/pcmanfm/desktopitemdelegate.h
@@ -49,6 +49,11 @@ public:
     margins_ = margins.expandedTo(QSize(0, 0));
   }
 
+  virtual QWidget* createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+  virtual void setEditorData(QWidget *editor, const QModelIndex &index) const;
+  virtual bool eventFilter(QObject *object, QEvent *event);
+  virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+
 private:
   void drawText(QPainter* painter, QStyleOptionViewItem& opt, QRectF& textRect) const;
 

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -117,6 +117,9 @@ protected Q_SLOTS:
   void onDeleteActivated();
   void onFilePropertiesActivated();
 
+  // inline renaming
+  void onClosingEditor(QWidget* editor, QAbstractItemDelegate::EndEditHint hint);
+
 private:
   void removeBottomGap();
   void paintBackground(QPaintEvent* event);


### PR DESCRIPTION
This depends on and follows https://github.com/lxde/libfm-qt/pull/67. It implements inline renaming for LXQt desktop.

A screenshot:

![inline](https://cloud.githubusercontent.com/assets/981076/24832410/d09f56f6-1cc4-11e7-8785-9f9fc03b7a12.png)
