### PR TITLE
Fix cursor on hovering desktop items

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -948,7 +948,7 @@ bool DesktopWindow::eventFilter(QObject* watched, QEvent* event) {
             break;
         }
     }
-    return false;
+    return Fm::FolderView::eventFilter(watched, event);
 }
 
 void DesktopWindow::childDropEvent(QDropEvent* e) {


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/477.

Desktop items also obey auto-selection setting now.