### PR TITLE
Fix pressing RETURN in location bar

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -359,8 +359,8 @@ void MainWindow::toggleMenuBar(bool checked) {
 
 void MainWindow::onPathEntryReturnPressed() {
     QString text = pathEntry_->text();
-    QByteArray utext = text.toUtf8();
-    chdir(Fm::FilePath::fromDisplayName(utext.constData()));
+    QByteArray utext = text.toLocal8Bit();
+    chdir(Fm::FilePath::fromPathStr(utext.constData()));
 }
 
 void MainWindow::onPathEntryEdited(const QString& text) {


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/479 with the same method used in `PathBar::pathForButton()`. I don't know why `Fm::FilePath::fromDisplayName()` was used or how `g_file_parse_name()` could give a correct path in it. The previous `libfm` function was far more complex.