### PR TITLE
Place dropped item at drop position

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -193,6 +193,7 @@ void DesktopWindow::setShadow(const QColor& color) {
 }
 
 void DesktopWindow::onOpenDirRequested(const Fm::FilePath& path, int target) {
+    Q_UNUSED(target);
     // open in new window unconditionally.
     Application* app = static_cast<Application*>(qApp);
     MainWindow* newWin = new MainWindow(path);
@@ -410,6 +411,9 @@ void DesktopWindow::onDesktopPreferences() {
 }
 
 void DesktopWindow::onRowsInserted(const QModelIndex& parent, int start, int end) {
+    Q_UNUSED(parent);
+    Q_UNUSED(start);
+    Q_UNUSED(end);
     queueRelayout();
 }
 
@@ -689,12 +693,7 @@ void DesktopWindow::loadItemPositions() {
                     && customPos.x() + listView_->gridSize().width() <= workArea.right() + 1
                     && customPos.y() + listView_->gridSize().height() <= workArea.bottom() + 1) {
                 // correct positions that are't aligned to the grid
-                qreal w = qAbs((qreal)customPos.x() - (qreal)workArea.x())
-                          / (qreal)(grid.width() + listView_->spacing());
-                qreal h = qAbs(customPos.y() - (qreal)workArea.y())
-                          / (qreal)(grid.height() + listView_->spacing());
-                customPos.setX(workArea.x() + qRound(w) * (grid.width() + listView_->spacing()));
-                customPos.setY(workArea.y() + qRound(h) * (grid.height() + listView_->spacing()));
+                alignToGrid(customPos, workArea.topLeft(), grid, listView_->spacing());
                 // FIXME: this is very inefficient
                 while(std::find(usedPos.cbegin(), usedPos.cend(), customPos) != usedPos.cend()) {
                     customPos.setY(customPos.y() + grid.height() + listView_->spacing());
@@ -955,11 +954,11 @@ bool DesktopWindow::eventFilter(QObject* watched, QEvent* event) {
 }
 
 void DesktopWindow::childDropEvent(QDropEvent* e) {
+    const QMimeData* mimeData = e->mimeData();
     bool moveItem = false;
     if(e->source() == listView_ && e->keyboardModifiers() == Qt::NoModifier) {
         // drag source is our list view, and no other modifier keys are pressed
         // => we're dragging desktop items
-        const QMimeData* mimeData = e->mimeData();
         if(mimeData->hasFormat("application/x-qabstractitemmodeldatalist")) {
             QModelIndex dropIndex = listView_->indexAt(e->pos());
             if(dropIndex.isValid()) { // drop on an item
@@ -978,7 +977,44 @@ void DesktopWindow::childDropEvent(QDropEvent* e) {
     }
     else {
         Fm::FolderView::childDropEvent(e);
+        // position dropped items successively, starting with the drop rectangle
+        if(mimeData->hasUrls()
+           && (e->dropAction() == Qt::CopyAction
+               || e->dropAction() == Qt::MoveAction
+               || e->dropAction() == Qt::LinkAction)) {
+            QList<QUrl> urlList = mimeData->urls();
+            for(int i = 0; i < urlList.count(); ++i) {
+                std::string name = urlList.at(i).fileName().toUtf8().constData();
+                if(!name.empty()) { // respect the positions of existing files
+                    QString desktopDir = XdgDir::readDesktopDir() + QString(QLatin1String("/"));
+                    if(!QFile::exists(desktopDir + QString::fromStdString(name))) {
+                        QSize grid = listView_->gridSize();
+                        QRect workArea = qApp->desktop()->availableGeometry(screenNum_);
+                        workArea.adjust(12, 12, -12, -12);
+                        QPoint pos = mapFromGlobal(e->pos());
+                        alignToGrid(pos, workArea.topLeft(), grid, listView_->spacing());
+                        if(i > 0)
+                            pos.setY(pos.y() + grid.height() + listView_->spacing());
+                        if(pos.y() + grid.height() > workArea.bottom() + 1) {
+                            pos.setX(pos.x() + grid.width() + listView_->spacing());
+                            pos.setY(workArea.top());
+                        }
+                        customItemPos_[name] = pos;
+                    }
+                }
+            }
+            saveItemPositions();
+        }
     }
+}
+
+void DesktopWindow::alignToGrid(QPoint& pos, const QPoint& topLeft, const QSize& grid, const int spacing) {
+    qreal w = qAbs((qreal)pos.x() - (qreal)topLeft.x())
+              / (qreal)(grid.width() + spacing);
+    qreal h = qAbs(pos.y() - (qreal)topLeft.y())
+              / (qreal)(grid.height() + spacing);
+    pos.setX(topLeft.x() + qRound(w) * (grid.width() + spacing));
+    pos.setY(topLeft.y() + qRound(h) * (grid.height() + spacing));
 }
 
 void DesktopWindow::closeEvent(QCloseEvent* event) {

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -123,6 +123,7 @@ protected Q_SLOTS:
 private:
     void removeBottomGap();
     void paintBackground(QPaintEvent* event);
+    static void alignToGrid(QPoint& pos, const QPoint& topLeft, const QSize& grid, const int spacing);
 
 private:
     Fm::ProxyFolderModel* proxyModel_;


### PR DESCRIPTION
Fixes (a part of) https://github.com/lxde/pcmanfm-qt/issues/500.

For a more natural "desk-top" experience, dropped items are positioned successively (top→bottom + left→right), starting with the drop position (rectangle).

IMO, there's no need to make this optional because most users expect such a behavior and if a user doesn't want it, he/she could use the context menu easily (see https://github.com/lxde/pcmanfm-qt/pull/499).