### PR TITLE
Fix jerky desktop items

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -95,6 +95,7 @@ protected:
 
     virtual void childDropEvent(QDropEvent* e) override;
     virtual void closeEvent(QCloseEvent* event) override;
+    virtual void paintEvent(QPaintEvent *event) override;
 
 protected Q_SLOTS:
     void onOpenDirRequested(const Fm::FilePath& path, int target);


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/497.

Desktop items may make redundant (and ugly) jumps when other items are added/removed. Here, such jumps are prevented by disabling view updates temporarily. For wallpaper painting not to be affected by (lack of) view updates, wallpaper is painted on the deaktop itself, not on its viewport.