### PR TITLE
Grey out files that have been Ctrl-X'ed

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1009,18 +1009,22 @@ void MainWindow::onBookmarkActionTriggered() {
 
 void MainWindow::on_actionCopy_triggered() {
     TabPage* page = currentPage();
+    page->copyTriggered();
     auto paths = page->selectedFilePaths();
     copyFilesToClipboard(paths);
 }
 
 void MainWindow::on_actionCut_triggered() {
     TabPage* page = currentPage();
+    page->cutTriggered();
     auto paths = page->selectedFilePaths();
     cutFilesToClipboard(paths);
 }
 
 void MainWindow::on_actionPaste_triggered() {
-    pasteFilesFromClipboard(currentPage()->path(), this);
+    TabPage* page = currentPage();
+    page->pasteTriggered();
+    pasteFilesFromClipboard(page->path(), this);
 }
 
 void MainWindow::on_actionDelete_triggered() {

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -200,6 +200,18 @@ public:
 
     void setCustomizedView(bool value);
 
+    void cutTriggered() {
+        folderView_->onCutTriggered();
+    }
+
+    void copyTriggered() {
+        folderView_->onCopyTriggered();
+    }
+
+    void pasteTriggered() {
+        folderView_->onPasteTriggered();
+    }
+
 Q_SIGNALS:
     void statusChanged(int type, QString statusText);
     void titleChanged(QString title);


### PR DESCRIPTION
Follows **libfm-qt** PR [#88](https://github.com/lxde/libfm-qt/pull/88) and concludes new proposed behavior.

Makes menu actions and keyboard shortcuts of Cut/Copy/Paste events responsive to added visual feedback of graying icons out by setting transparency.