### PR TITLE
Update statusbar size info when needed

### DIFF
--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -210,7 +210,8 @@ Q_SIGNALS:
 
 protected Q_SLOTS:
     void onSelChanged();
-    void restoreScrollPos();
+    void onUiUpdated();
+    void onFileSizeChanged(const QModelIndex& index);
 
 private:
     void freeFolder();


### PR DESCRIPTION
pcmanfm-qt didn't update the size info while selected (big) files were being downloaded or pasted or when their sizes were changed in any way, unless the folder was reloaded. This patch fixes that.