### PR TITLE
Fix showing/hiding hidden files

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -489,6 +489,9 @@ void MainWindow::on_actionFolderProperties_triggered() {
 void MainWindow::on_actionShowHidden_triggered(bool checked) {
     currentPage()->setShowHidden(checked);
     ui.sidePane->setShowHidden(checked);
+    if(!currentPage()->hasCustomizedView()) {
+        static_cast<Application*>(qApp)->settings().setShowHidden(checked);  // remember globally
+    }
 }
 
 void MainWindow::on_actionByFileName_triggered(bool checked) {
@@ -916,7 +919,9 @@ void MainWindow::onTabPageSortFilterChanged() {
             settings.setSortOrder(tabPage->sortOrder());
             settings.setSortFolderFirst(tabPage->sortFolderFirst());
             settings.setSortCaseSensitive(tabPage->sortCaseSensitive());
+            settings.setShowHidden(tabPage->showHidden()); // remember globally , as in on_actionShowHidden_triggered()
         }
+        tabPage->setShowHidden(tabPage->showHidden()); // change status text and perfolder setting
     }
 }
 

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -604,10 +604,13 @@ void TabPage::setShowHidden(bool showHidden) {
             static_cast<Application*>(qApp)->settings().saveFolderSettings(path(), folderSettings_);
         }
     }
-    if(!proxyModel_ || showHidden == proxyModel_->showHidden()) {
+    if(!proxyModel_) {
         return;
     }
-    proxyModel_->setShowHidden(showHidden);
+    if(showHidden != proxyModel_->showHidden()) {
+        proxyModel_->setShowHidden(showHidden);
+    }
+    // this may also be called by MainWindow::onTabPageSortFilterChanged to set status message
     statusText_[StatusTextNormal] = formatStatusText();
     Q_EMIT statusChanged(StatusTextNormal, statusText_[StatusTextNormal]);
 }

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -106,7 +106,7 @@ public:
     void setSortCaseSensitive(bool value);
 
     bool showHidden() {
-        return folderSettings_.showHidden();
+        return proxyModel_->showHidden();
     }
 
     void setShowHidden(bool showHidden);


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/533.

The bugs that are fixed by this patch:

(1) The status message wasn't changed when hidden files were shown/hidden by context menu (in contrast to `Ctrl+H`).
(2) Showing hidden files wasn't remembered globally.
(3) Sometimes, the setting for showing hidden files wasn't saved for customized folders either.

Current behavior:

(1) If hidden files are shown/hidden inside a folder *without* customization, the setting will be remembered globally for all folders *without* customization.
(2) If hidden files are shown/hidden inside a folder *with* customization, the setting will be remembered only for that folder and not globally.

The behavior implemented by this patch is usually expected for hidden files, as is the case with well-known file managers.

IMHO, this behavior is better to be generalized to other view settings too and it's unfortunate that pcmanfm-qt has no way to inform the user that a folder is customized other than by toggling checkboxes in menus -- but that's another matter to discuss.