### PR TITLE
Wallpaper Slide Show

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -679,11 +679,11 @@ void Application::updateFromSettings() {
     }
 }
 
-void Application::updateDesktopsFromSettings() {
+void Application::updateDesktopsFromSettings(bool changeSlide) {
     QVector<DesktopWindow*>::iterator it;
     for(it = desktopWindows_.begin(); it != desktopWindows_.end(); ++it) {
         DesktopWindow* desktopWindow = static_cast<DesktopWindow*>(*it);
-        desktopWindow->updateFromSettings(settings_);
+        desktopWindow->updateFromSettings(settings_, changeSlide);
     }
 }
 

--- a/pcmanfm/application.h
+++ b/pcmanfm/application.h
@@ -87,7 +87,7 @@ public:
     }
 
     void updateFromSettings();
-    void updateDesktopsFromSettings();
+    void updateDesktopsFromSettings(bool changeSlide = true);
 
     void openFolderInTerminal(Fm::FilePath path);
     void openFolders(Fm::FileInfoList files);

--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -310,6 +310,144 @@ A space is also reserved for 3 lines of text.</string>
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="bgPage">
+      <attribute name="title">
+       <string>Slide Show</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QGroupBox" name="slideShow">
+         <property name="title">
+          <string>Enable Slide Show</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="0" colspan="7">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Wallpaper image folder:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="6">
+           <widget class="QPushButton" name="folderBrowse">
+            <property name="text">
+             <string>Browse</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QSpinBox" name="hours">
+            <property name="suffix">
+             <string> hour(s)</string>
+            </property>
+            <property name="maximum">
+             <number>24</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>and</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="margin">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_11">
+            <property name="toolTip">
+             <string>Intervals less than 5min will be ignored</string>
+            </property>
+            <property name="text">
+             <string>Interval:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="4">
+           <widget class="QSpinBox" name="minutes">
+            <property name="suffix">
+             <string> minute(s)</string>
+            </property>
+            <property name="maximum">
+             <number>55</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="5">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>10</width>
+              <height>5</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="0" colspan="6">
+           <widget class="QLineEdit" name="imageFolder">
+            <property name="placeholderText">
+             <string>Wallpaper folder</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Minimum</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>5</width>
+              <height>5</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="3" column="0" colspan="6">
+           <widget class="QCheckBox" name="randomize">
+            <property name="text">
+             <string>Randomize the slide show</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="advancedPage">
       <attribute name="title">
        <string>Advanced</string>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -84,6 +84,14 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   qDebug("wallpaper: %s", settings.wallpaper().toUtf8().data());
   ui.imageFile->setText(settings.wallpaper());
 
+  ui.slideShow->setChecked(settings.slideShowInterval() > 0);
+  ui.imageFolder->setText(settings.wallpaperDir());
+  int minutes = qMax(settings.slideShowInterval() / 60000, 5); // 5 min at least
+  ui.hours->setValue(minutes / 60);
+  ui.minutes->setValue(minutes % 60);
+  ui.randomize->setChecked(settings.wallpaperRandomize());
+  connect(ui.folderBrowse, &QPushButton::clicked, this, &DesktopPreferencesDialog::onFolderBrowseClicked);
+
   for(std::size_t i = 0; i < G_N_ELEMENTS(iconSizes); ++i) {
     int size = iconSizes[i];
     ui.iconSize->addItem(QString("%1 x %1").arg(size), size);
@@ -145,12 +153,22 @@ void DesktopPreferencesDialog::applySettings()
   settings.setWallpaper(ui.imageFile->text());
   int mode = ui.wallpaperMode->itemData(ui.wallpaperMode->currentIndex()).toInt();
   settings.setWallpaperMode(mode);
+
+  settings.setWallpaperDir(ui.imageFolder->text());
+  int interval = 0;
+  if(ui.slideShow->isChecked())
+    interval = (ui.minutes->value() + 60 * ui.hours->value()) * 60000;
+  settings.setSlideShowInterval(interval);
+  settings.setWallpaperRandomize(ui.randomize->isChecked());
+
   settings.setDesktopIconSize(ui.iconSize->itemData(ui.iconSize->currentIndex()).toInt());
+
   settings.setDesktopFont(ui.font->font());
   settings.setDesktopBgColor(ui.backgroundColor->color());
   settings.setDesktopFgColor(ui.textColor->color());
   settings.setDesktopShadowColor(ui.shadowColor->color());
   settings.setShowWmMenu(ui.showWmMenu->isChecked());
+
   settings.setDesktopCellMargins(QSize(ui.hMargin->value(), ui.vMargin->value()));
 
   settings.save();
@@ -164,7 +182,7 @@ void DesktopPreferencesDialog::onApplyClicked()
 
 void DesktopPreferencesDialog::accept() {
   applySettings();
-  static_cast<Application*>(qApp)->updateDesktopsFromSettings();
+  static_cast<Application*>(qApp)->updateDesktopsFromSettings(false); // don't change slide wallpaper on clicking OK
   QDialog::accept();
 }
 
@@ -198,6 +216,19 @@ void DesktopPreferencesDialog::onBrowseClicked() {
     QString filename;
     filename = dlg.selectedFiles().first();
     ui.imageFile->setText(filename);
+  }
+}
+
+void DesktopPreferencesDialog::onFolderBrowseClicked() {
+  QFileDialog dlg;
+  dlg.setAcceptMode(QFileDialog::AcceptOpen);
+  dlg.setFileMode(QFileDialog::Directory);
+  dlg.setOption(QFileDialog::ShowDirsOnly);
+  dlg.setDirectory(QDir::home().path());
+  if(dlg.exec() == QDialog::Accepted) {
+    QString foldername;
+    foldername = dlg.selectedFiles().first();
+    ui.imageFolder->setText(foldername);
   }
 }
 

--- a/pcmanfm/desktoppreferencesdialog.h
+++ b/pcmanfm/desktoppreferencesdialog.h
@@ -46,6 +46,7 @@ protected Q_SLOTS:
   void onApplyClicked();
   void onWallpaperModeChanged(int index);
   void onBrowseClicked();
+  void onFolderBrowseClicked();
   void onBrowseDesktopFolderClicked();
   void lockMargins(bool lock);
 

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -65,10 +65,16 @@ public:
     void setDesktopFolder();
     void setWallpaperFile(QString filename);
     void setWallpaperMode(WallpaperMode mode = WallpaperStretch);
+    void setLastSlide(QString filename);
+    void setWallpaperDir(QString dirname);
+    void setSlideShowInterval(int interval);
+    void setWallpaperRandomize(bool randomize);
 
     // void setWallpaperAlpha(qreal alpha);
     void updateWallpaper();
-    void updateFromSettings(Settings& settings);
+    bool pickWallpaper();
+    void nextWallpaper();
+    void updateFromSettings(Settings& settings, bool changeSlide = true);
 
     void queueRelayout(int delay = 0);
 
@@ -136,6 +142,11 @@ private:
     QColor shadowColor_;
     QString wallpaperFile_;
     WallpaperMode wallpaperMode_;
+    QString lastSlide_;
+    QString wallpaperDir_;
+    int slideShowInterval_;
+    QTimer* wallpaperTimer_;
+    bool wallpaperRandomize_;
     QPixmap wallpaperPixmap_;
     Launcher fileLauncher_;
     bool showWmMenu_;

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -63,6 +63,10 @@ Settings::Settings():
     closeOnUnmount_(false),
     wallpaperMode_(0),
     wallpaper_(),
+    lastSlide_(),
+    wallpaperDir_(),
+    slideShowInterval_(0),
+    wallpaperRandomize_(false),
     desktopBgColor_(),
     desktopFgColor_(),
     desktopShadowColor_(),
@@ -204,6 +208,10 @@ bool Settings::loadFile(QString filePath) {
     settings.beginGroup("Desktop");
     wallpaperMode_ = wallpaperModeFromString(settings.value("WallpaperMode").toString());
     wallpaper_ = settings.value("Wallpaper").toString();
+    lastSlide_ = settings.value("LastSlide").toString();
+    wallpaperDir_ = settings.value("WallpaperDirectory").toString();
+    slideShowInterval_ = settings.value("SlideShowInterval", 0).toInt();
+    wallpaperRandomize_ = settings.value("WallpaperRandomize").toBool();
     desktopBgColor_.setNamedColor(settings.value("BgColor", "#000000").toString());
     desktopFgColor_.setNamedColor(settings.value("FgColor", "#ffffff").toString());
     desktopShadowColor_.setNamedColor(settings.value("ShadowColor", "#000000").toString());
@@ -323,6 +331,10 @@ bool Settings::saveFile(QString filePath) {
     settings.beginGroup("Desktop");
     settings.setValue("WallpaperMode", wallpaperModeToString(wallpaperMode_));
     settings.setValue("Wallpaper", wallpaper_);
+    settings.setValue("LastSlide", lastSlide_);
+    settings.setValue("WallpaperDirectory", wallpaperDir_);
+    settings.setValue("SlideShowInterval", slideShowInterval_);
+    settings.setValue("WallpaperRandomize", wallpaperRandomize_);
     settings.setValue("BgColor", desktopBgColor_.name());
     settings.setValue("FgColor", desktopFgColor_.name());
     settings.setValue("ShadowColor", desktopShadowColor_.name());

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -235,6 +235,38 @@ public:
         wallpaper_ = wallpaper;
     }
 
+    QString wallpaperDir() const {
+        return wallpaperDir_;
+    }
+
+    void setLastSlide(QString wallpaper) {
+        lastSlide_ = wallpaper;
+    }
+
+    QString lastSlide() const {
+        return lastSlide_;
+    }
+
+    void setWallpaperDir(QString dir) {
+        wallpaperDir_ = dir;
+    }
+
+    int slideShowInterval() const {
+        return slideShowInterval_;
+    }
+
+    void setSlideShowInterval(int interval) {
+        slideShowInterval_ = interval;
+    }
+
+    bool wallpaperRandomize() const {
+       return wallpaperRandomize_;
+    }
+
+    void setWallpaperRandomize(bool randomize) {
+        wallpaperRandomize_ = randomize;
+    }
+
     const QColor& desktopBgColor() const {
         return desktopBgColor_;
     }
@@ -773,6 +805,10 @@ private:
 
     int wallpaperMode_;
     QString wallpaper_;
+    QString lastSlide_;
+    QString wallpaperDir_;
+    int slideShowInterval_;
+    bool wallpaperRandomize_;
     QColor desktopBgColor_;
     QColor desktopFgColor_;
     QColor desktopShadowColor_;


### PR DESCRIPTION
Fixes https://github.com/lxde/lxqt/issues/608.

The new options are added to Desktop Preferences in a new tab. The slide-show interval is between 5min and 24h55min. An option is also added for randomizing the slide show.

Unusual cases -- like when a wallpaper is removed, the folder doesn't exist, etc. -- are dealt with appropriately.

P.S.
(1) I also fixed what @pmattern saw as a minor issue in an old discussion; now, pressing OK in the the Desktop Preferences doesn't change the current slide unless needed (KDE has also fixed this in its slide show).
(2) This patch is not new -- I use it for half a year.