### PR TITLE
Disable menubar actions that cannot be used

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -197,7 +197,7 @@
     <addaction name="menuToolbars"/>
     <addaction name="menuPathBarStyle"/>
    </widget>
-   <widget class="QMenu" name="menu_Editw">
+   <widget class="QMenu" name="menu_Edit">
     <property name="title">
      <string>&amp;Edit</string>
     </property>
@@ -245,7 +245,7 @@
     <addaction name="actionFindFiles"/>
    </widget>
    <addaction name="menu_File"/>
-   <addaction name="menu_Editw"/>
+   <addaction name="menu_Edit"/>
    <addaction name="menu_View"/>
    <addaction name="menu_Go"/>
    <addaction name="menu_Bookmarks"/>

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -187,6 +187,7 @@ private:
     void loadBookmarksMenu();
     void updateUIForCurrentPage();
     void updateViewMenuForCurrentPage();
+    void updateEditSelectedActions();
     void updateStatusBarForCurrentPage();
     void setRTLIcons(bool isRTL);
     void createPathBar(bool usePathButtons);


### PR DESCRIPTION
Follows https://github.com/lxde/libfm-qt/pull/121, disabling menubar Edit actions when they cannot be performed.

Also a typo is corrected.