### PR TITLE
Update status message appropriately

### DIFF
--- a/pcmanfm/CMakeLists.txt
+++ b/pcmanfm/CMakeLists.txt
@@ -4,6 +4,7 @@ set(pcmanfm_SRCS
     mainwindow.cpp
     tabpage.cpp
     tabbar.cpp
+    statusbar.cpp
     view.cpp
     launcher.cpp
     preferencesdialog.cpp

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -252,7 +252,7 @@
    <addaction name="menu_Tool"/>
    <addaction name="menu_Help"/>
   </widget>
-  <widget class="QStatusBar" name="statusbar"/>
+  <widget class="PCManFM::StatusBar" name="statusbar"/>
   <widget class="QToolBar" name="toolBar">
    <property name="contextMenuPolicy">
     <enum>Qt::PreventContextMenu</enum>
@@ -834,6 +834,12 @@
    <class>PCManFM::TabBar</class>
    <extends>QWidget</extends>
    <header>tabbar.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PCManFM::StatusBar</class>
+   <extends>QStatusBar</extends>
+   <header>statusbar.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -906,7 +906,7 @@ void MainWindow::onTabPageTitleChanged(QString title) {
         setWindowTitle(title);
 
         // Since TabPage::titleChanged is emitted on changing directory,
-        // the Paste action should be disabled if when the new directory isn't writable
+        // the enabled state of Paste action should be updated here
         bool isWritable(false);
         if(tabPage && tabPage->folder()) {
             if(auto info = tabPage->folder()->info()) {
@@ -923,8 +923,9 @@ void MainWindow::onTabPageStatusChanged(int type, QString statusText) {
         switch(type) {
         case TabPage::StatusTextNormal:
         case TabPage::StatusTextSelectedFiles: {
-            // FIXME: updating the status text so frequently is a little bit ineffiecient
-            QString text = statusText = tabPage->statusText(TabPage::StatusTextSelectedFiles);
+            // although the status text may change very frequently,
+            // the text of PCManFM::StatusBar is updated with a delay
+            QString text = tabPage->statusText(TabPage::StatusTextSelectedFiles);
             if(text.isEmpty()) {
                 ui.statusbar->showMessage(tabPage->statusText(TabPage::StatusTextNormal));
             }
@@ -942,7 +943,6 @@ void MainWindow::onTabPageStatusChanged(int type, QString statusText) {
 
     // Since TabPage::statusChanged is always emitted after View::selChanged,
     // there is no need to connect a separate slot to the latter signal
-    // in order to update the enabled state of Edit actions for selected files
     updateEditSelectedActions();
 }
 

--- a/pcmanfm/statusbar.cpp
+++ b/pcmanfm/statusbar.cpp
@@ -1,0 +1,62 @@
+/*
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "statusbar.h"
+
+#define MESSAGE_DELAY 250
+
+namespace PCManFM {
+
+StatusBar::StatusBar(QWidget *parent):
+  QStatusBar(parent),
+  lastTimeOut_(0) {
+    statusLabel_ = new QLabel();
+    statusLabel_->setIndent(4);
+    addWidget(statusLabel_);
+
+    messageTimer_ = new QTimer (this);
+    messageTimer_->setSingleShot(true);
+    messageTimer_->setInterval(MESSAGE_DELAY);
+    connect(messageTimer_, &QTimer::timeout, this, &StatusBar::reallyShowMessage);
+}
+
+StatusBar::~StatusBar() {
+    if(messageTimer_) {
+        messageTimer_->stop();
+        delete messageTimer_;
+    }
+}
+
+void StatusBar::showMessage(const QString &message, int timeout) {
+    // don't show the message immediately
+    lastMessage_ = message;
+    lastTimeOut_ = timeout;
+    if(!messageTimer_->isActive()) {
+        messageTimer_->start();
+    }
+}
+
+void StatusBar::reallyShowMessage() {
+    if(lastTimeOut_ == 0) {
+        // set the text on the label for it not to change when a menubar item is focused
+        statusLabel_->setText(lastMessage_);
+    }
+    else {
+        QStatusBar::showMessage(lastMessage_, lastTimeOut_);
+    }
+}
+
+}

--- a/pcmanfm/statusbar.cpp
+++ b/pcmanfm/statusbar.cpp
@@ -15,16 +15,49 @@
 */
 
 #include "statusbar.h"
+#include <QPainter>
+#include <QStyleOption>
 
 #define MESSAGE_DELAY 250
 
 namespace PCManFM {
 
+Label::Label(QWidget* parent, Qt::WindowFlags f):
+  QLabel(parent, f),
+  lastWidth_(0) {
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    // set a min width to prevent the window from widening with long texts
+    setMinimumWidth(fontMetrics().averageCharWidth() * 10);
+}
+
+// A simplified version of QLabel::paintEvent()
+// without pixmap or shortcut but with eliding.
+void Label::paintEvent(QPaintEvent* /*event*/) {
+    QRect cr = contentsRect().adjusted(margin(), margin(), -margin(), -margin());
+    QString txt = text();
+    // if the text is changed or its rect is resized (due to window resizing),
+    // find whether it needs to be elided...
+    if (txt != lastText_ || cr.width() != lastWidth_) {
+        lastText_ = txt;
+        lastWidth_ = cr.width();
+        elidedText_ = fontMetrics().elidedText(txt, Qt::ElideMiddle, cr.width());
+    }
+    // ... then, draw the (elided) text
+    if(!elidedText_.isEmpty()) {
+        QPainter painter(this);
+        QStyleOption opt;
+        opt.initFrom(this);
+        style()->drawItemText(&painter, cr, alignment(), opt.palette, isEnabled(), elidedText_, foregroundRole());
+    }
+}
+
 StatusBar::StatusBar(QWidget *parent):
   QStatusBar(parent),
   lastTimeOut_(0) {
-    statusLabel_ = new QLabel();
-    statusLabel_->setIndent(4);
+    statusLabel_ = new Label();
+    statusLabel_->setFrameShape(QFrame::NoFrame);
+    // 4px space on both sides (not to be mixed with the permanent widget)
+    statusLabel_->setContentsMargins(4, 0, 4, 0);
     addWidget(statusLabel_);
 
     messageTimer_ = new QTimer (this);
@@ -51,8 +84,9 @@ void StatusBar::showMessage(const QString &message, int timeout) {
 
 void StatusBar::reallyShowMessage() {
     if(lastTimeOut_ == 0) {
-        // set the text on the label for it not to change when a menubar item is focused
-        statusLabel_->setText(lastMessage_);
+        // set the text on the label to prevent its disappearance on focusing menubar items
+        // and also ensure that it contsains no newline (because file names may contain it)
+        statusLabel_->setText(lastMessage_.replace(QLatin1Char('\n'), QLatin1Char(' ')));
     }
     else {
         QStatusBar::showMessage(lastMessage_, lastTimeOut_);

--- a/pcmanfm/statusbar.h
+++ b/pcmanfm/statusbar.h
@@ -1,0 +1,48 @@
+/*
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef FM_STATUSBAR_H
+#define FM_STATUSBAR_H
+
+#include <QStatusBar>
+#include <QLabel>
+#include <QTimer>
+
+namespace PCManFM {
+
+class StatusBar : public QStatusBar {
+Q_OBJECT
+
+public:
+    explicit StatusBar(QWidget *parent = 0);
+    ~StatusBar();
+
+public Q_SLOTS:
+    void showMessage(const QString &message, int timeout = 0);
+
+protected Q_SLOTS:
+    void reallyShowMessage();
+
+private:
+    QLabel* statusLabel_; // for a stable text
+    QTimer* messageTimer_;
+    QString lastMessage_;
+    int lastTimeOut_;
+};
+
+}
+
+#endif // FM_STATUSBAR_H

--- a/pcmanfm/statusbar.h
+++ b/pcmanfm/statusbar.h
@@ -23,6 +23,21 @@
 
 namespace PCManFM {
 
+class Label : public QLabel {
+Q_OBJECT
+
+public:
+    explicit Label(QWidget *parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    QString elidedText_;
+    QString lastText_;
+    int lastWidth_;
+};
+
 class StatusBar : public QStatusBar {
 Q_OBJECT
 
@@ -37,7 +52,7 @@ protected Q_SLOTS:
     void reallyShowMessage();
 
 private:
-    QLabel* statusLabel_; // for a stable text
+    Label* statusLabel_; // for a stable (elided) text
     QTimer* messageTimer_;
     QString lastMessage_;
     int lastTimeOut_;

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -372,6 +372,9 @@ void TabPage::chdir(Fm::FilePath newPath, bool addHistory) {
             return;
         }
 
+        // reset the status selected text
+        statusText_[StatusTextSelectedFiles] = QString();
+
         // remember the previous folder path that we have browsed.
         lastFolderPath_ = folder_->path();
 


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/569 and https://github.com/lxde/pcmanfm-qt/issues/571

This patch fixes:

(1) A bug, because of which, the status text wasn't updated when the folder was selected before changing dir into it;
(2) Too frequent and redundant text updates; and
(3) A Qt "feature", because of which, the status text disappeared on focusing menubar items.