### PR TITLE
Fix icon sizes

### DIFF
--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -31,10 +31,6 @@
 
 namespace PCManFM {
 
-static int bigIconSizes[] = {96, 72, 64, 48, 36, 32, 24, 20};
-static int smallIconSizes[] = {48, 36, 32, 24, 20, 16, 12};
-static int thumbnailIconSizes[] = {256, 224, 192, 160, 128, 96, 64};
-
 PreferencesDialog::PreferencesDialog(QString activePage, QWidget* parent):
     QDialog(parent) {
     ui.setupUi(this);
@@ -135,15 +131,17 @@ void PreferencesDialog::initArchivers(Settings& settings) {
 void PreferencesDialog::initDisplayPage(Settings& settings) {
     initIconThemes(settings);
     // icon sizes
-    for(std::size_t i = 0; i < G_N_ELEMENTS(bigIconSizes); ++i) {
-        int size = bigIconSizes[i];
+    QList<int>sizes = settings.iconSizes(Settings::Big);
+    for(int i = 0; i < sizes.size(); ++i) {
+        int size = sizes.at(i);
         ui.bigIconSize->addItem(QString("%1 x %1").arg(size), size);
         if(settings.bigIconSize() == size) {
             ui.bigIconSize->setCurrentIndex(i);
         }
     }
-    for(std::size_t i = 0; i < G_N_ELEMENTS(smallIconSizes); ++i) {
-        int size = smallIconSizes[i];
+    sizes = settings.iconSizes(Settings::Small);
+    for(int i = 0; i < sizes.size(); ++i) {
+        int size = sizes.at(i);
         QString text = QString("%1 x %1").arg(size);
         ui.smallIconSize->addItem(text, size);
         if(settings.smallIconSize() == size) {
@@ -155,8 +153,9 @@ void PreferencesDialog::initDisplayPage(Settings& settings) {
             ui.sidePaneIconSize->setCurrentIndex(i);
         }
     }
-    for(std::size_t i = 0; i < G_N_ELEMENTS(thumbnailIconSizes); ++i) {
-        int size = thumbnailIconSizes[i];
+    sizes = settings.iconSizes(Settings::Thumbnail);
+    for(int i = 0; i < sizes.size(); ++i) {
+        int size = sizes.at(i);
         ui.thumbnailIconSize->addItem(QString("%1 x %1").arg(size), size);
         if(settings.thumbnailIconSize() == size) {
             ui.thumbnailIconSize->setCurrentIndex(i);

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -131,17 +131,16 @@ void PreferencesDialog::initArchivers(Settings& settings) {
 void PreferencesDialog::initDisplayPage(Settings& settings) {
     initIconThemes(settings);
     // icon sizes
-    QList<int>sizes = settings.iconSizes(Settings::Big);
-    for(int i = 0; i < sizes.size(); ++i) {
-        int size = sizes.at(i);
+    int i = 0;
+    for (const auto & size : Settings::iconSizes(Settings::Big)) {
         ui.bigIconSize->addItem(QString("%1 x %1").arg(size), size);
         if(settings.bigIconSize() == size) {
             ui.bigIconSize->setCurrentIndex(i);
         }
+        ++i;
     }
-    sizes = settings.iconSizes(Settings::Small);
-    for(int i = 0; i < sizes.size(); ++i) {
-        int size = sizes.at(i);
+    i = 0;
+    for (const auto & size : Settings::iconSizes(Settings::Small)) {
         QString text = QString("%1 x %1").arg(size);
         ui.smallIconSize->addItem(text, size);
         if(settings.smallIconSize() == size) {
@@ -152,14 +151,15 @@ void PreferencesDialog::initDisplayPage(Settings& settings) {
         if(settings.sidePaneIconSize() == size) {
             ui.sidePaneIconSize->setCurrentIndex(i);
         }
+        ++i;
     }
-    sizes = settings.iconSizes(Settings::Thumbnail);
-    for(int i = 0; i < sizes.size(); ++i) {
-        int size = sizes.at(i);
+    i = 0;
+    for (const auto & size : Settings::iconSizes(Settings::Thumbnail)) {
         ui.thumbnailIconSize->addItem(QString("%1 x %1").arg(size), size);
         if(settings.thumbnailIconSize() == size) {
             ui.thumbnailIconSize->setCurrentIndex(i);
         }
+        ++i;
     }
 
     ui.siUnit->setChecked(settings.siUnit());

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -266,10 +266,10 @@ bool Settings::loadFile(QString filePath) {
     shadowHidden_ = settings.value("ShadowHidden", false).toBool();
 
     // override config in libfm's FmConfig
-    bigIconSize_ = settings.value("BigIconSize", 48).toInt();
-    smallIconSize_ = settings.value("SmallIconSize", 24).toInt();
-    sidePaneIconSize_ = settings.value("SidePaneIconSize", 24).toInt();
-    thumbnailIconSize_ = settings.value("ThumbnailIconSize", 128).toInt();
+    bigIconSize_ = toIconSize(settings.value("BigIconSize", 48).toInt(), Big);
+    smallIconSize_ = toIconSize(settings.value("SmallIconSize", 24).toInt(), Small);
+    sidePaneIconSize_ = toIconSize(settings.value("SidePaneIconSize", 24).toInt(), Small);
+    thumbnailIconSize_ = toIconSize(settings.value("ThumbnailIconSize", 128).toInt(), Thumbnail);
 
     folderViewCellMargins_ = (settings.value("FolderViewCellMargins", QSize(3, 3)).toSize()
                               .expandedTo(QSize(0, 0))).boundedTo(QSize(48, 48));
@@ -437,6 +437,33 @@ bool Settings::saveFile(QString filePath) {
     settings.endGroup();
 
     return true;
+}
+
+QList<int> Settings::iconSizes(IconType type) const {
+    QList<int> sizes;
+    switch(type) {
+    case Big:
+        sizes << 96 << 72 << 64 << 48 << 32;
+        break;
+    case Thumbnail:
+        sizes << 256 << 224 << 192 << 160 << 128 << 96 << 64;
+        break;
+    case Small:
+    default:
+        sizes << 48 << 32 << 24 << 22 << 16;
+        break;
+    }
+    return sizes;
+}
+
+int Settings::toIconSize(int size, IconType type) const {
+    QList<int> sizes = iconSizes(type);
+    for (int i = 0; i < sizes.size(); ++i) {
+        if(size >= sizes.at(i)) {
+            return sizes.at(i);
+        }
+    }
+    return sizes.at(sizes.size() - 1);
 }
 
 static const char* bookmarkOpenMethodToString(OpenDirTargetType value) {

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -439,31 +439,32 @@ bool Settings::saveFile(QString filePath) {
     return true;
 }
 
-QList<int> Settings::iconSizes(IconType type) const {
-    QList<int> sizes;
+const QList<int> & Settings::iconSizes(IconType type) {
+    static const QList<int> sizes_big = {96, 72, 64, 48, 32};
+    static const QList<int> sizes_thumbnail = {256, 224, 192, 160, 128, 96, 64};
+    static const QList<int> sizes_small = {48, 32, 24, 22, 16};
     switch(type) {
     case Big:
-        sizes << 96 << 72 << 64 << 48 << 32;
+        return sizes_big;
         break;
     case Thumbnail:
-        sizes << 256 << 224 << 192 << 160 << 128 << 96 << 64;
+        return sizes_thumbnail;
         break;
     case Small:
     default:
-        sizes << 48 << 32 << 24 << 22 << 16;
+        return sizes_small;
         break;
     }
-    return sizes;
 }
 
 int Settings::toIconSize(int size, IconType type) const {
-    QList<int> sizes = iconSizes(type);
-    for (int i = 0; i < sizes.size(); ++i) {
-        if(size >= sizes.at(i)) {
-            return sizes.at(i);
+    const QList<int> & sizes = iconSizes(type);
+    for (const auto & s : sizes) {
+        if(size >= s) {
+            return s;
         }
     }
-    return sizes.at(sizes.size() - 1);
+    return sizes.back();
 }
 
 static const char* bookmarkOpenMethodToString(OpenDirTargetType value) {

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -121,8 +121,16 @@ private:
 class Settings : public QObject {
     Q_OBJECT
 public:
+    enum IconType {
+        Small,
+        Big,
+        Thumbnail
+    };
+
     Settings();
     virtual ~Settings();
+
+    QList<int> iconSizes(IconType type) const;
 
     bool load(QString profile = "default");
     bool save(QString profile = QString());
@@ -836,6 +844,8 @@ public:
     }
 
 private:
+    int toIconSize(int size, IconType type) const;
+
     QString profileName_;
     bool supportTrash_;
 

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -130,8 +130,6 @@ public:
     Settings();
     virtual ~Settings();
 
-    QList<int> iconSizes(IconType type) const;
-
     bool load(QString profile = "default");
     bool save(QString profile = QString());
 
@@ -139,6 +137,7 @@ public:
     bool saveFile(QString filePath);
 
     static QString xdgUserConfigDir();
+    static const QList<int> & iconSizes(IconType type);
 
     QString profileDir(QString profile, bool useFallback = false);
 


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/562

Non-standard small icon sizes are removed because tiny icons might be blurry with them. Non-standard sizes for relatively big icons are kept though.

Also icon sizes are corrected if manually put into config file, so that the sizes used by Preferences dialog are always respected.