### PR TITLE
Just fixed my typo in search settings

### DIFF
--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -812,7 +812,7 @@ public:
     }
 
     bool searchContentRegexp() const {
-        return searchNameRegexp_;
+        return searchContentRegexp_;
     }
 
     void setSearchContentRegexp(bool reg) {


### PR DESCRIPTION
It prevented the regular expression option from being saved for contents search.