### PR TITLE
Tab DND

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1291,12 +1291,7 @@ void MainWindow::dropTab() {
     // its page to a new tab in the second window
     TabPage* dropPage = lastActive_->currentPage();
     if(dropPage) {
-        disconnect(dropPage, &TabPage::titleChanged, lastActive_, &MainWindow::onTabPageTitleChanged);
-        disconnect(dropPage, &TabPage::statusChanged, lastActive_, &MainWindow::onTabPageStatusChanged);
-        disconnect(dropPage, &TabPage::openDirRequested, lastActive_, &MainWindow::onTabPageOpenDirRequested);
-        disconnect(dropPage, &TabPage::sortFilterChanged, lastActive_, &MainWindow::onTabPageSortFilterChanged);
-        disconnect(dropPage, &TabPage::backwardRequested, lastActive_, &MainWindow::on_actionGoBack_triggered);
-        disconnect(dropPage, &TabPage::forwardRequested, lastActive_, &MainWindow::on_actionGoForward_triggered);
+        disconnect(dropPage, nullptr, lastActive_, nullptr);
 
         // release mouse before tab removal because otherwise, the source tabbar
         // might not be updated properly with tab reordering during a fast drag-and-drop
@@ -1321,12 +1316,7 @@ void MainWindow::detachTab() {
     // close the tab and move its page to a new window
     TabPage* dropPage = currentPage();
     if(dropPage) {
-        disconnect(dropPage, &TabPage::titleChanged, this, &MainWindow::onTabPageTitleChanged);
-        disconnect(dropPage, &TabPage::statusChanged, this, &MainWindow::onTabPageStatusChanged);
-        disconnect(dropPage, &TabPage::openDirRequested, this, &MainWindow::onTabPageOpenDirRequested);
-        disconnect(dropPage, &TabPage::sortFilterChanged, this, &MainWindow::onTabPageSortFilterChanged);
-        disconnect(dropPage, &TabPage::backwardRequested, this, &MainWindow::on_actionGoBack_triggered);
-        disconnect(dropPage, &TabPage::forwardRequested, this, &MainWindow::on_actionGoForward_triggered);
+        disconnect(dropPage, nullptr, this, nullptr);
 
         ui.tabBar->releaseMouse(); // as in dropTab()
 

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -30,6 +30,7 @@
 #include <QShortcut>
 #include <QKeySequence>
 #include <QSettings>
+#include <QMimeData>
 #include <QStandardPaths>
 #include <QDebug>
 
@@ -114,6 +115,7 @@ MainWindow::MainWindow(Fm::FilePath path):
     connect(ui.tabBar, &QTabBar::tabCloseRequested, this, &MainWindow::onTabBarCloseRequested);
     connect(ui.tabBar, &QTabBar::tabMoved, this, &MainWindow::onTabBarTabMoved);
     connect(ui.tabBar, &QTabBar::customContextMenuRequested, this, &MainWindow::tabContextMenu);
+    connect(ui.tabBar, &TabBar::tabDetached, this, &MainWindow::detachTab);
     connect(ui.stackedWidget, &QStackedWidget::widgetRemoved, this, &MainWindow::onStackedWidgetWidgetRemoved);
 
     // FIXME: should we make the filter bar a per-view configuration?
@@ -271,16 +273,17 @@ MainWindow::MainWindow(Fm::FilePath path):
     }
 
     // size from settings
-    if(settings.rememberWindowSize()) {
-        resize(settings.windowWidth(), settings.windowHeight());
-        if(settings.windowMaximized()) {
-            setWindowState(windowState() | Qt::WindowMaximized);
-        }
-    }
+    resize(settings.windowWidth(), settings.windowHeight());
+    if(settings.rememberWindowSize() && settings.windowMaximized()) {
+        setWindowState(windowState() | Qt::WindowMaximized);
+     }
 
     if(QApplication::layoutDirection() == Qt::RightToLeft) {
         setRTLIcons(true);
     }
+
+    // we want tab dnd
+    setAcceptDrops(true);
 }
 
 MainWindow::~MainWindow() {
@@ -311,27 +314,35 @@ void MainWindow::createPathBar(bool usePathButtons) {
     ui.actionGo->setVisible(!usePathButtons);
 }
 
-// add a new tab
-int MainWindow::addTab(Fm::FilePath path) {
+int MainWindow::addTabWithPage(TabPage* page, Fm::FilePath path) {
+    if(page == nullptr) {
+        return -1;
+    }
+    page->setFileLauncher(&fileLauncher_);
+    int index = ui.stackedWidget->addWidget(page);
+    connect(page, &TabPage::titleChanged, this, &MainWindow::onTabPageTitleChanged);
+    connect(page, &TabPage::statusChanged, this, &MainWindow::onTabPageStatusChanged);
+    connect(page, &TabPage::openDirRequested, this, &MainWindow::onTabPageOpenDirRequested);
+    connect(page, &TabPage::sortFilterChanged, this, &MainWindow::onTabPageSortFilterChanged);
+    connect(page, &TabPage::backwardRequested, this, &MainWindow::on_actionGoBack_triggered);
+    connect(page, &TabPage::forwardRequested, this, &MainWindow::on_actionGoForward_triggered);
+
+    if(path) {
+        page->chdir(path, true);
+    }
+    ui.tabBar->insertTab(index, page->windowTitle());
+ 
     Settings& settings = static_cast<Application*>(qApp)->settings();
-
-    TabPage* newPage = new TabPage(this);
-    newPage->setFileLauncher(&fileLauncher_);
-    int index = ui.stackedWidget->addWidget(newPage);
-    connect(newPage, &TabPage::titleChanged, this, &MainWindow::onTabPageTitleChanged);
-    connect(newPage, &TabPage::statusChanged, this, &MainWindow::onTabPageStatusChanged);
-    connect(newPage, &TabPage::openDirRequested, this, &MainWindow::onTabPageOpenDirRequested);
-    connect(newPage, &TabPage::sortFilterChanged, this, &MainWindow::onTabPageSortFilterChanged);
-    connect(newPage, &TabPage::backwardRequested, this, &MainWindow::on_actionGoBack_triggered);
-    connect(newPage, &TabPage::forwardRequested, this, &MainWindow::on_actionGoForward_triggered);
-
-    newPage->chdir(path, true);
-    ui.tabBar->insertTab(index, newPage->windowTitle());
-
     if(!settings.alwaysShowTabs()) {
         ui.tabBar->setVisible(ui.tabBar->count() > 1);
     }
     return index;
+}
+
+// add a new tab
+int MainWindow::addTab(Fm::FilePath path) {
+    TabPage* newPage = new TabPage(this);
+    return addTabWithPage(newPage, path);
 }
 
 void MainWindow::toggleMenuBar(bool checked) {
@@ -1253,6 +1264,80 @@ void MainWindow::focusPathEntry() {
     }
     else if(pathBar_ != nullptr) {  // use button-style path bar
         pathBar_->openEditor();
+    }
+}
+
+void MainWindow::dragEnterEvent(QDragEnterEvent* event) {
+    if(event->mimeData()->hasFormat("application/pcmanfm-qt-tab")) {
+        event->acceptProposedAction();
+    }
+}
+
+void MainWindow::dropEvent(QDropEvent* event) {
+    if(event->mimeData()->hasFormat("application/pcmanfm-qt-tab")) {
+        dropTab();
+    }
+    event->acceptProposedAction();
+}
+
+void MainWindow::dropTab() {
+    if(lastActive_ == nullptr // impossible
+       || lastActive_ == this) { // don't drop on the same window
+        ui.tabBar->finishMouseMoveEvent();
+        return;
+    }
+
+    // close the tab in the first window and add
+    // its page to a new tab in the second window
+    TabPage* dropPage = lastActive_->currentPage();
+    if(dropPage) {
+        disconnect(dropPage, &TabPage::titleChanged, lastActive_, &MainWindow::onTabPageTitleChanged);
+        disconnect(dropPage, &TabPage::statusChanged, lastActive_, &MainWindow::onTabPageStatusChanged);
+        disconnect(dropPage, &TabPage::openDirRequested, lastActive_, &MainWindow::onTabPageOpenDirRequested);
+        disconnect(dropPage, &TabPage::sortFilterChanged, lastActive_, &MainWindow::onTabPageSortFilterChanged);
+        disconnect(dropPage, &TabPage::backwardRequested, lastActive_, &MainWindow::on_actionGoBack_triggered);
+        disconnect(dropPage, &TabPage::forwardRequested, lastActive_, &MainWindow::on_actionGoForward_triggered);
+
+        // release mouse before tab removal because otherwise, the source tabbar
+        // might not be updated properly with tab reordering during a fast drag-and-drop
+        lastActive_->ui.tabBar->releaseMouse();
+
+        QWidget* page = lastActive_->ui.stackedWidget->currentWidget();
+        lastActive_->ui.stackedWidget->removeWidget(page);
+        int index = addTabWithPage(dropPage);
+        ui.tabBar->setCurrentIndex(index);
+    }
+    else {
+        ui.tabBar->finishMouseMoveEvent(); // impossible
+    }
+}
+
+void MainWindow::detachTab() {
+    if (ui.stackedWidget->count() == 1) { // don't detach a single tab
+        ui.tabBar->finishMouseMoveEvent();
+        return;
+    }
+
+    // close the tab and move its page to a new window
+    TabPage* dropPage = currentPage();
+    if(dropPage) {
+        disconnect(dropPage, &TabPage::titleChanged, this, &MainWindow::onTabPageTitleChanged);
+        disconnect(dropPage, &TabPage::statusChanged, this, &MainWindow::onTabPageStatusChanged);
+        disconnect(dropPage, &TabPage::openDirRequested, this, &MainWindow::onTabPageOpenDirRequested);
+        disconnect(dropPage, &TabPage::sortFilterChanged, this, &MainWindow::onTabPageSortFilterChanged);
+        disconnect(dropPage, &TabPage::backwardRequested, this, &MainWindow::on_actionGoBack_triggered);
+        disconnect(dropPage, &TabPage::forwardRequested, this, &MainWindow::on_actionGoForward_triggered);
+
+        ui.tabBar->releaseMouse(); // as in dropTab()
+
+        QWidget* page = ui.stackedWidget->currentWidget();
+        ui.stackedWidget->removeWidget(page);
+        MainWindow* newWin = new MainWindow();
+        newWin->addTabWithPage(dropPage);
+        newWin->show();
+    }
+    else {
+        ui.tabBar->finishMouseMoveEvent(); // impossible
     }
 }
 

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -173,6 +173,7 @@ protected Q_SLOTS:
     }
     void focusPathEntry();
     void toggleMenuBar(bool checked);
+    void detachTab();
 
     void onBookmarksChanged();
 
@@ -182,6 +183,8 @@ protected:
     void closeTab(int index);
     virtual void resizeEvent(QResizeEvent* event) override;
     virtual void closeEvent(QCloseEvent* event) override;
+    virtual void dragEnterEvent(QDragEnterEvent* event) override;
+    virtual void dropEvent(QDropEvent* event) override;
 
 private:
     void loadBookmarksMenu();
@@ -191,6 +194,8 @@ private:
     void updateStatusBarForCurrentPage();
     void setRTLIcons(bool isRTL);
     void createPathBar(bool usePathButtons);
+    int addTabWithPage(TabPage* page, Fm::FilePath path = Fm::FilePath());
+    void dropTab();
 
 private:
     Ui::MainWindow ui;

--- a/pcmanfm/tabbar.cpp
+++ b/pcmanfm/tabbar.cpp
@@ -28,7 +28,8 @@
 namespace PCManFM {
 
 TabBar::TabBar(QWidget *parent):
-    QTabBar(parent)
+    QTabBar(parent),
+    dragStarted_(false)
 {
 }
 

--- a/pcmanfm/tabbar.h
+++ b/pcmanfm/tabbar.h
@@ -31,10 +31,23 @@ class TabBar : public QTabBar {
 Q_OBJECT
 
 public:
-  explicit TabBar(QWidget *parent = 0);
+    explicit TabBar(QWidget *parent = 0);
+    void finishMouseMoveEvent();
+    void releaseMouse();
+
+Q_SIGNALS:
+    void tabDetached();
 
 protected:
-	void mouseReleaseEvent(QMouseEvent *event);
+    void mouseReleaseEvent(QMouseEvent *event);
+    // from qtabbar.cpp
+    virtual void mousePressEvent(QMouseEvent *event);
+    virtual void mouseMoveEvent(QMouseEvent *event);
+    virtual void dragEnterEvent(QDragEnterEvent *event);
+
+private:
+    QPoint dragStartPosition_;
+    bool dragStarted_;
 };
 
 }


### PR DESCRIPTION
Closes https://github.com/lxde/pcmanfm-qt/issues/428.

Tabs can be detached or moved to another window by drag-and-drop. Also windows can be unified with tab DND.