### PR TITLE
Really cancel multiple renaming on cancelling

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -971,7 +971,9 @@ void DesktopWindow::onRenameActivated() {
     auto files = selectedFiles();
     if(!files.empty()) {
         for(auto& info: files) {
-            Fm::renameFile(info, nullptr);
+            if(!Fm::renameFile(info, nullptr)) {
+                break;
+            }
         }
      }
 }

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1116,7 +1116,9 @@ void MainWindow::on_actionRename_triggered() {
     }
     if(!files.empty()) {
         for(auto& file: files) {
-            Fm::renameFile(file, nullptr);
+            if(!Fm::renameFile(file, nullptr)) {
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
This follows and depends on https://github.com/lxde/libfm-qt/pull/130. It cancels shortcut/menubar renaming of multiple files when Cancel/Esc is pressed.