### PR TITLE
Wait for events to be processed before chdir

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -287,12 +287,14 @@ MainWindow::~MainWindow() {
 }
 
 void MainWindow::chdir(Fm::FilePath path) {
-    TabPage* page = currentPage();
-    if(page) {
-        ui.filterBar->clear();
-        page->chdir(path, true);
-        updateUIForCurrentPage();
-    }
+    QTimer::singleShot(0, [this, path] {
+        TabPage* page = currentPage();
+        if(page) {
+            ui.filterBar->clear();
+            page->chdir(path, true);
+            updateUIForCurrentPage();
+        }
+    });
 }
 
 void MainWindow::createPathBar(bool usePathButtons) {
@@ -375,33 +377,40 @@ void MainWindow::onPathBarMiddleClickChdir(const Fm::FilePath& dirPath) {
 }
 
 void MainWindow::on_actionGoUp_triggered() {
-    TabPage* page = currentPage();
-
-    if(page) {
-        ui.filterBar->clear();
-        page->up();
-        updateUIForCurrentPage();
-    }
+    QTimer::singleShot(0, [this] {
+        TabPage* page = currentPage();
+    
+        if(page) {
+            ui.filterBar->clear();
+            page->up();
+            updateUIForCurrentPage();
+        }
+    });
 }
 
 void MainWindow::on_actionGoBack_triggered() {
-    TabPage* page = currentPage();
-
-    if(page) {
-        ui.filterBar->clear();
-        page->backward();
-        updateUIForCurrentPage();
-    }
+    QTimer::singleShot(0, [this] {
+        TabPage* page = currentPage();
+    
+        if(page) {
+            ui.filterBar->clear();
+            page->backward();
+            updateUIForCurrentPage();
+        }
+    });
 }
 
 void MainWindow::on_actionGoForward_triggered() {
-    TabPage* page = currentPage();
-
-    if(page) {
-        ui.filterBar->clear();
-        page->forward();
-        updateUIForCurrentPage();
-    }
+    QTimer::singleShot(0, [this] {
+        TabPage* page = currentPage();
+    
+        if(page) {
+            ui.filterBar->clear();
+            page->forward();
+            updateUIForCurrentPage();
+        }
+    });
+    
 }
 
 void MainWindow::on_actionHome_triggered() {

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -288,9 +288,8 @@ MainWindow::~MainWindow() {
 
 void MainWindow::chdir(Fm::FilePath path) {
     // wait until queued events are processed
-    QTimer::singleShot(0, [this, path] {
-        TabPage* page = currentPage();
-        if(page) {
+    QTimer::singleShot(0, this, [this, path] {
+        if(TabPage* page = currentPage()) {
             ui.filterBar->clear();
             page->chdir(path, true);
             updateUIForCurrentPage();
@@ -378,10 +377,8 @@ void MainWindow::onPathBarMiddleClickChdir(const Fm::FilePath& dirPath) {
 }
 
 void MainWindow::on_actionGoUp_triggered() {
-    QTimer::singleShot(0, [this] {
-        TabPage* page = currentPage();
-    
-        if(page) {
+    QTimer::singleShot(0, this, [this] {
+        if(TabPage* page = currentPage()) {
             ui.filterBar->clear();
             page->up();
             updateUIForCurrentPage();
@@ -390,10 +387,8 @@ void MainWindow::on_actionGoUp_triggered() {
 }
 
 void MainWindow::on_actionGoBack_triggered() {
-    QTimer::singleShot(0, [this] {
-        TabPage* page = currentPage();
-    
-        if(page) {
+    QTimer::singleShot(0, this, [this] {
+        if(TabPage* page = currentPage()) {
             ui.filterBar->clear();
             page->backward();
             updateUIForCurrentPage();
@@ -402,10 +397,8 @@ void MainWindow::on_actionGoBack_triggered() {
 }
 
 void MainWindow::on_actionGoForward_triggered() {
-    QTimer::singleShot(0, [this] {
-        TabPage* page = currentPage();
-    
-        if(page) {
+    QTimer::singleShot(0, this, [this] {
+        if(TabPage* page = currentPage()) {
             ui.filterBar->clear();
             page->forward();
             updateUIForCurrentPage();

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -287,6 +287,7 @@ MainWindow::~MainWindow() {
 }
 
 void MainWindow::chdir(Fm::FilePath path) {
+    // wait until queued events are processed
     QTimer::singleShot(0, [this, path] {
         TabPage* page = currentPage();
         if(page) {


### PR DESCRIPTION
Fixes https://github.com/lxde/lxqt/issues/1410

In all cases of changing directory, a `QTimer::singleShot()` is used to prevent crashes when the action is triggered too fast.