### PR TITLE
Fix direction of statusbar message

### DIFF
--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -466,8 +466,8 @@ void TabPage::reload() {
 // 202b RIGHT-TO-LEFT EMBEDDING
 // 202c POP DIRECTIONAL FORMATTING
 QString TabPage::encloseWithBidiMarks(const QString& text) {
-    QChar bidiMark = text.isRightToLeft()? QChar(0x200f) : QChar(0x200e);
-    QChar embedBidiMark = text.isRightToLeft()? QChar(0x202b) : QChar(0x202a);
+    QChar bidiMark = text.isRightToLeft() ? QChar(0x200f) : QChar(0x200e);
+    QChar embedBidiMark = text.isRightToLeft() ? QChar(0x202b) : QChar(0x202a);
     return embedBidiMark+text+bidiMark+QChar(0x202c);
 }
 
@@ -486,14 +486,14 @@ void TabPage::onSelChanged() {
                       .arg(encloseWithBidiMarks(Fm::formatFileSize(fi->size(), fm_config->si_unit))) // FIXME: deprecate fm_config
                       .arg(encloseWithBidiMarks(fi->mimeType()->desc()))
                       .arg(QString::fromUtf8(
-                          (!layoutDirection() == Qt::LeftToRight) ? "\u200f" : "\u200e"));
+                          (layoutDirection() == Qt::RightToLeft) ? "\u200f" : "\u200e"));
             }
             else {
                 msg = QString("%3\"%1\" %3%2")
                       .arg(encloseWithBidiMarks(fi->displayName()))
                       .arg(encloseWithBidiMarks(fi->mimeType()->desc()))
                       .arg(QString::fromUtf8(
-                          (!layoutDirection() == Qt::LeftToRight) ? "\u200f" : "\u200e"));
+                          (layoutDirection() == Qt::RightToLeft) ? "\u200f" : "\u200e"));
             }
             /* FIXME: should we support statusbar plugins as in the gtk+ version? */
         }

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -460,9 +460,15 @@ void TabPage::reload() {
     }
 }
 
-QString TabPage::encloseWithBidiMarks(QString text) {
+// 200e LEFT-TO-RIGHT MARK
+// 200f RIGHT-TO-LEFT MARK
+// 202a LEFT-TO-RIGHT EMBEDDING
+// 202b RIGHT-TO-LEFT EMBEDDING
+// 202c POP DIRECTIONAL FORMATTING
+QString TabPage::encloseWithBidiMarks(QString& text) {
     QChar bidiMark = text.isRightToLeft()? QChar(0x200f) : QChar(0x200e);
-    return bidiMark+text+bidiMark;
+    QChar embedBidiMark = text.isRightToLeft()? QChar(0x202b) : QChar(0x202a);
+    return embedBidiMark+text+bidiMark+QChar(0x202c);
 }
 
 // when the current selection in the folder view is changed
@@ -484,8 +490,8 @@ void TabPage::onSelChanged() {
             }
             else {
                 msg = QString("%3\"%1\" %3%2")
-                      .arg(encloseWithBidiMarks(fi->displayName())(
-                      .arg(encloseWithBidiMarks(fi->mimeType()->desc())
+                      .arg(encloseWithBidiMarks(fi->displayName()))
+                      .arg(encloseWithBidiMarks(fi->mimeType()->desc()))
                       .arg(QString::fromUtf8(
                           (!layoutDirection() == Qt::LeftToRight) ? "\u200f" : "\u200e"));
             }

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -460,6 +460,11 @@ void TabPage::reload() {
     }
 }
 
+QString TabPage::encloseWithBidiMarks(QString text) {
+    QChar bidiMark = text.isRightToLeft()? QChar(0x200f) : QChar(0x200e);
+    return bidiMark+text+bidiMark;
+}
+
 // when the current selection in the folder view is changed
 void TabPage::onSelChanged() {
     QString msg;
@@ -470,15 +475,19 @@ void TabPage::onSelChanged() {
         if(numSel == 1) { /* only one file is selected */
             auto& fi = files.front();
             if(!fi->isDir()) {
-                msg = QString("\"%1\" (%2) %3")
-                      .arg(fi->displayName())
-                      .arg(Fm::formatFileSize(fi->size(), fm_config->si_unit)) // FIXME: deprecate fm_config
-                      .arg(fi->mimeType()->desc());
+                msg = QString("%4\"%1\" %4(%2) %4%3")
+                      .arg(encloseWithBidiMarks(fi->displayName()))
+                      .arg(encloseWithBidiMarks(Fm::formatFileSize(fi->size(), fm_config->si_unit))) // FIXME: deprecate fm_config
+                      .arg(encloseWithBidiMarks(fi->mimeType()->desc()))
+                      .arg(QString::fromUtf8(
+                          (!layoutDirection() == Qt::LeftToRight) ? "\u200f" : "\u200e"));
             }
             else {
-                msg = QString("\"%1\" %2")
-                      .arg(fi->displayName())
-                      .arg(fi->mimeType()->desc());
+                msg = QString("%3\"%1\" %3%2")
+                      .arg(encloseWithBidiMarks(fi->displayName())(
+                      .arg(encloseWithBidiMarks(fi->mimeType()->desc())
+                      .arg(QString::fromUtf8(
+                          (!layoutDirection() == Qt::LeftToRight) ? "\u200f" : "\u200e"));
             }
             /* FIXME: should we support statusbar plugins as in the gtk+ version? */
         }

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -465,7 +465,7 @@ void TabPage::reload() {
 // 202a LEFT-TO-RIGHT EMBEDDING
 // 202b RIGHT-TO-LEFT EMBEDDING
 // 202c POP DIRECTIONAL FORMATTING
-QString TabPage::encloseWithBidiMarks(QString& text) {
+QString TabPage::encloseWithBidiMarks(const QString& text) {
     QChar bidiMark = text.isRightToLeft()? QChar(0x200f) : QChar(0x200e);
     QChar embedBidiMark = text.isRightToLeft()? QChar(0x202b) : QChar(0x202a);
     return embedBidiMark+text+bidiMark+QChar(0x202c);

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -485,15 +485,13 @@ void TabPage::onSelChanged() {
                       .arg(encloseWithBidiMarks(fi->displayName()))
                       .arg(encloseWithBidiMarks(Fm::formatFileSize(fi->size(), fm_config->si_unit))) // FIXME: deprecate fm_config
                       .arg(encloseWithBidiMarks(fi->mimeType()->desc()))
-                      .arg(QString::fromUtf8(
-                          (layoutDirection() == Qt::RightToLeft) ? "\u200f" : "\u200e"));
+                      .arg((layoutDirection() == Qt::RightToLeft) ? QChar(0x200f) : QChar(0x200e));
             }
             else {
                 msg = QString("%3\"%1\" %3%2")
                       .arg(encloseWithBidiMarks(fi->displayName()))
                       .arg(encloseWithBidiMarks(fi->mimeType()->desc()))
-                      .arg(QString::fromUtf8(
-                          (layoutDirection() == Qt::RightToLeft) ? "\u200f" : "\u200e"));
+                      .arg((layoutDirection() == Qt::RightToLeft) ? QChar(0x200f) : QChar(0x200e));
             }
             /* FIXME: should we support statusbar plugins as in the gtk+ version? */
         }

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -218,7 +218,7 @@ private:
     QString formatStatusText();
 
     // Adds bidi marks (RLM/LRM/RLE/LRE/POP) around the text for the statusbar.
-    QString encloseWithBidiMarks(QString& text);
+    QString encloseWithBidiMarks(const QString& text);
 
     void onFolderStartLoading();
     void onFolderFinishLoading();

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -200,6 +200,10 @@ public:
 
     void setCustomizedView(bool value);
 
+protected:
+    // Adds bidi marks (RLM/LRM) around the text for the statusbar.
+    QString encloseWithBidiMarks(QString text);
+
 Q_SIGNALS:
     void statusChanged(int type, QString statusText);
     void titleChanged(QString title);

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -200,10 +200,6 @@ public:
 
     void setCustomizedView(bool value);
 
-protected:
-    // Adds bidi marks (RLM/LRM) around the text for the statusbar.
-    QString encloseWithBidiMarks(QString text);
-
 Q_SIGNALS:
     void statusChanged(int type, QString statusText);
     void titleChanged(QString title);
@@ -220,6 +216,9 @@ protected Q_SLOTS:
 private:
     void freeFolder();
     QString formatStatusText();
+
+    // Adds bidi marks (RLM/LRM/RLE/LRE/POP) around the text for the statusbar.
+    QString encloseWithBidiMarks(QString& text);
 
     void onFolderStartLoading();
     void onFolderFinishLoading();


### PR DESCRIPTION
We are displaying the filename at the first in the statusbar, which means that if it's RTL and the locale is LTR, the whole text will get messed up, resulting in hard-to-read and wrong display of the name and the information.

Fixes #379