### PR TITLE
Sweep a desktop mess under the carpet

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -105,6 +105,8 @@ protected:
 protected Q_SLOTS:
     void onOpenDirRequested(const Fm::FilePath& path, int target);
     void onDesktopPreferences();
+    void selectAll();
+    void toggleDesktop();
 
     void onRowsAboutToBeRemoved(const QModelIndex& parent, int start, int end);
     void onRowsInserted(const QModelIndex& parent, int start, int end);
@@ -129,6 +131,7 @@ protected Q_SLOTS:
 
 private:
     void removeBottomGap();
+    void addDesktopActions(QMenu* menu);
     void paintBackground(QPaintEvent* event);
     static void alignToGrid(QPoint& pos, const QPoint& topLeft, const QSize& grid, const int spacing);
 
@@ -151,6 +154,7 @@ private:
     QPixmap wallpaperPixmap_;
     Launcher fileLauncher_;
     bool showWmMenu_;
+    bool desktopHideItems_;
 
     int screenNum_;
     std::unordered_map<std::string, QPoint> customItemPos_;

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -73,6 +73,7 @@ Settings::Settings():
     desktopIconSize_(48),
     showWmMenu_(false),
     desktopShowHidden_(false),
+    desktopHideItems_(false),
     desktopSortOrder_(Qt::AscendingOrder),
     desktopSortColumn_(Fm::FolderModel::ColumnFileMTime),
     desktopSortFolderFirst_(true),
@@ -230,6 +231,7 @@ bool Settings::loadFile(QString filePath) {
     desktopIconSize_ = settings.value("DesktopIconSize", 48).toInt();
     showWmMenu_ = settings.value("ShowWmMenu", false).toBool();
     desktopShowHidden_ = settings.value("ShowHidden", false).toBool();
+    desktopHideItems_ = settings.value("HideItems", false).toBool();
 
     desktopSortOrder_ = sortOrderFromString(settings.value("SortOrder").toString());
     desktopSortColumn_ = sortColumnFromString(settings.value("SortColumn").toString());
@@ -357,6 +359,7 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue("DesktopIconSize", desktopIconSize_);
     settings.setValue("ShowWmMenu", showWmMenu_);
     settings.setValue("ShowHidden", desktopShowHidden_);
+    settings.setValue("HideItems", desktopHideItems_);
     settings.setValue("SortOrder", sortOrderToString(desktopSortOrder_));
     settings.setValue("SortColumn", sortColumnToString(desktopSortColumn_));
     settings.setValue("SortFolderFirst", desktopSortFolderFirst_);

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -330,6 +330,14 @@ public:
         desktopShowHidden_ = desktopShowHidden;
     }
 
+    bool desktopHideItems() const {
+        return desktopHideItems_;
+    }
+
+    void setDesktopHideItems(bool hide) {
+        desktopHideItems_ = hide;
+    }
+
     Qt::SortOrder desktopSortOrder() const {
         return desktopSortOrder_;
     }
@@ -350,7 +358,7 @@ public:
         return desktopSortFolderFirst_;
     }
 
-    void setSesktopSortFolderFirst(bool desktopFolderFirst) {
+    void setDesktopSortFolderFirst(bool desktopFolderFirst) {
         desktopSortFolderFirst_ = desktopFolderFirst;
     }
 
@@ -874,6 +882,7 @@ private:
     bool showWmMenu_;
 
     bool desktopShowHidden_;
+    bool desktopHideItems_;
     Qt::SortOrder desktopSortOrder_;
     Fm::FolderModel::ColumnId desktopSortColumn_;
     bool desktopSortFolderFirst_;


### PR DESCRIPTION
Closes https://github.com/lxde/pcmanfm-qt/issues/609

A checkable context menu-item ("Hide Desktop Items") for quickly hiding/showing all dekstop items and stopping/starting interaction with Dekstop. Its state is remembered.