### PR TITLE
Follow GLib to know if a file is hidden

### DIFF
--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -48,7 +48,6 @@ class ProxyFilter : public Fm::ProxyFolderModelFilter {
 public:
     bool filterAcceptsRow(const Fm::ProxyFolderModel* model, const std::shared_ptr<const Fm::FileInfo>& info) const;
     virtual ~ProxyFilter() {}
-    void setVirtHidden(const std::shared_ptr<Fm::Folder>& folder);
     QString getFilterStr() {
         return filterStr_;
     }
@@ -58,7 +57,6 @@ public:
 
 private:
     QString filterStr_;
-    QStringList virtHiddenList_;
 };
 
 class TabPage : public QWidget {


### PR DESCRIPTION
Follows and depends on https://github.com/lxde/libfm-qt/pull/155.

We don't need to check `.hidden` because GLib already does that (and more).