### PR TITLE
Drop usage of Fm::IconTheme

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -109,7 +109,6 @@ Application::Application(int& argc, char** argv):
 
         if(settings_.useFallbackIconTheme()) {
             QIcon::setThemeName(settings_.fallbackIconThemeName());
-            Fm::IconTheme::checkChanged();
         }
 
         // Check if LXQt Session is running. LXQt has it's own Desktop Folder

--- a/pcmanfm/autorundialog.cpp
+++ b/pcmanfm/autorundialog.cpp
@@ -19,7 +19,6 @@
 
 
 #include "autorundialog.h"
-#include <libfm-qt/icontheme.h>
 #include <QListWidgetItem>
 #include "application.h"
 #include "mainwindow.h"


### PR DESCRIPTION
..as it is not needed any more.

Note: must be merged before or right after lxde/libfm-qt#165