### PR TITLE
Show desktop preferences only in LXQt

### DIFF
--- a/pcmanfm/pcmanfm-qt-desktop-pref.desktop.in
+++ b/pcmanfm/pcmanfm-qt-desktop-pref.desktop.in
@@ -4,3 +4,4 @@ Exec=pcmanfm-qt --desktop-pref=general
 Icon=user-desktop
 Categories=Settings;Qt;DesktopSettings;
 StartupNotify=true
+OnlyShowIn=LXQt;


### PR DESCRIPTION
The desktop manager is [autostarted only in LXQt](https://github.com/lxqt/pcmanfm-qt/blob/f73e319d1b3cee9f18c0866937213fd5b70c45d6/autostart/lxqt-desktop.desktop.in#L5). Most desktop environments have their own desktop manager, therefore showing "Desktop" entry in their application launchers is confusing.