### PR TITLE
Consistent visibility of multi-screen desktop items on Wayland

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -979,7 +979,7 @@ void DesktopWindow::updateFromSettings(Settings& settings, bool changeSlide, boo
     setBackground(settings.desktopBgColor());
     setShadow(settings.desktopShadowColor());
     fileLauncher_.setOpenWithDefaultFileManager(settings.openWithDefaultFileManager());
-    desktopHideItems_ = settings.desktopHideItems();
+    desktopHideItems_ = settings.desktopHideItems(static_cast<Application*>(qApp)->underWayland() ? screenName_ : QString());
     if(desktopHideItems_) {
         // hide all items by hiding the list view and also
         // prevent the current item from being changed by arrow keys
@@ -1139,7 +1139,7 @@ void DesktopWindow::addDesktopActions(QMenu* menu) {
 void DesktopWindow::toggleDesktop() {
     desktopHideItems_ = !desktopHideItems_;
     Settings& settings = static_cast<Application*>(qApp)->settings();
-    settings.setDesktopHideItems(desktopHideItems_);
+    settings.setDesktopHideItems(desktopHideItems_, static_cast<Application*>(qApp)->underWayland() ? screenName_ : QString());
     listView_->setVisible(!desktopHideItems_);
     // a relayout is needed on showing the items for the first time
     // because the positions aren't updated while the view is hidden

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -242,6 +242,8 @@ bool Settings::loadFile(QString filePath) {
     settings.endGroup();
 
     settings.beginGroup(QStringLiteral("Desktop"));
+    screenNames_ = settings.value(QStringLiteral("ScreenNames")).toStringList();
+    screenNames_.removeDuplicates();
     wallpaperMode_ = wallpaperModeFromString(settings.value(QStringLiteral("WallpaperMode")).toString());
     wallpaper_ = settings.value(QStringLiteral("Wallpaper")).toString();
     wallpaperDialogSize_ = settings.value(QStringLiteral("WallpaperDialogSize"), QSize(700, 500)).toSize();
@@ -264,7 +266,13 @@ bool Settings::loadFile(QString filePath) {
     desktopIconSize_ = settings.value(QStringLiteral("DesktopIconSize"), 48).toInt();
     desktopShortcuts_ = settings.value(QStringLiteral("DesktopShortcuts")).toStringList();
     desktopShowHidden_ = settings.value(QStringLiteral("ShowHidden"), false).toBool();
+
+    // X11
     desktopHideItems_ = settings.value(QStringLiteral("HideItems"), false).toBool();
+    // Wayland
+    for(const auto& screenName : std::as_const(screenNames_)) {
+        desktopHideItemsOnScreens_.insert(screenName, settings.value(QStringLiteral("HideItems-%1").arg(screenName), false).toBool());
+    }
 
     desktopSortOrder_ = sortOrderFromString(settings.value(QStringLiteral("SortOrder")).toString());
     desktopSortColumn_ = sortColumnFromString(settings.value(QStringLiteral("SortColumn")).toString());
@@ -407,6 +415,7 @@ bool Settings::saveFile(QString filePath) {
     settings.endGroup();
 
     settings.beginGroup(QStringLiteral("Desktop"));
+    settings.setValue(QStringLiteral("ScreenNames"), screenNames_);
     settings.setValue(QStringLiteral("WallpaperMode"), QString::fromUtf8(wallpaperModeToString(wallpaperMode_)));
     settings.setValue(QStringLiteral("Wallpaper"), wallpaper_);
     settings.setValue(QStringLiteral("WallpaperDialogSize"), wallpaperDialogSize_);
@@ -424,7 +433,14 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue(QStringLiteral("DesktopIconSize"), desktopIconSize_);
     settings.setValue(QStringLiteral("DesktopShortcuts"), desktopShortcuts_);
     settings.setValue(QStringLiteral("ShowHidden"), desktopShowHidden_);
+
+    // X11
     settings.setValue(QStringLiteral("HideItems"), desktopHideItems_);
+    // Wayland
+    for(const auto& screenName : std::as_const(screenNames_)) {
+        settings.setValue(QStringLiteral("HideItems-%1").arg(screenName), desktopHideItemsOnScreens_.value(screenName, false));
+    }
+
     settings.setValue(QStringLiteral("SortOrder"), QString::fromUtf8(sortOrderToString(desktopSortOrder_)));
     settings.setValue(QStringLiteral("SortColumn"), QString::fromUtf8(sortColumnToString(desktopSortColumn_)));
     settings.setValue(QStringLiteral("SortFolderFirst"), desktopSortFolderFirst_);

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -399,12 +399,23 @@ public:
         desktopShowHidden_ = desktopShowHidden;
     }
 
-    bool desktopHideItems() const {
-        return desktopHideItems_;
+    bool desktopHideItems(const QString& screenName = QString()) const {
+        if(screenName.isEmpty()) { // X11
+            return desktopHideItems_;
+        }
+        return desktopHideItemsOnScreens_.value(screenName, false); // Wayland
     }
 
-    void setDesktopHideItems(bool hide) {
-        desktopHideItems_ = hide;
+    void setDesktopHideItems(bool hide, const QString& screenName = QString()) {
+        if(screenName.isEmpty()) { // X11
+            desktopHideItems_ = hide;
+        }
+        else { // Wayland
+            if(!screenNames_.contains(screenName)) {
+                screenNames_ << screenName;
+            }
+            desktopHideItemsOnScreens_.insert(screenName, hide);
+        }
     }
 
     Qt::SortOrder desktopSortOrder() const {
@@ -1104,6 +1115,7 @@ private:
 
     bool desktopShowHidden_;
     bool desktopHideItems_;
+    QHash<QString, bool> desktopHideItemsOnScreens_; // on Wayland
     Qt::SortOrder desktopSortOrder_;
     Fm::FolderModel::ColumnId desktopSortColumn_;
     bool desktopSortFolderFirst_;
@@ -1196,6 +1208,8 @@ private:
     // recent files
     int recentFilesNumber_;
     QStringList recentFiles_;
+
+    QStringList screenNames_; // on Wayland
 };
 
 }


### PR DESCRIPTION
Hiding desktop items is made dependent on Wayland screen. The change is backward-compatible, in the sense that it doesn't affect X11, where all screens share a single extended desktop.

Closes https://github.com/lxqt/pcmanfm-qt/issues/2109

NOTE: The code is written in a way to make it easier to add more backward-compatible, screen-dependent key-value pairs, although that's not needed for now.