### PR TITLE
Remove redundant spacing for filter bar

### DIFF
--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -130,6 +130,7 @@ TabPage::TabPage(QWidget* parent):
 
     verticalLayout = new QVBoxLayout(this);
     verticalLayout->setContentsMargins(0, 0, 0, 0);
+    verticalLayout->setSpacing(0);
 
     folderView_ = new View(settings.viewMode(), this);
     folderView_->setMargins(settings.folderViewCellMargins());


### PR DESCRIPTION
Eliminate double spacing on the top of filter bar.

`verticalLayout` is only used for separating the folder view and the filter bar. The filter bar already had spacing, thus there was an excessive gap on the top.

Before:
<img width="661" height="142" alt="before_" src="https://github.com/user-attachments/assets/2349a72b-8ded-4725-875b-41187c06dd53" />
<img width="660" height="115" alt="before_2" src="https://github.com/user-attachments/assets/2f15c781-4347-4485-a857-963196301637" />

After:
<img width="656" height="136" alt="after_" src="https://github.com/user-attachments/assets/794c651f-ff99-43a0-b6d5-f1129c9f4870" />
<img width="658" height="107" alt="after_2" src="https://github.com/user-attachments/assets/e3208854-c3b3-4de1-9f36-0e7351348862" />
