### PR TITLE
wayland appid/class fix

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -97,6 +97,7 @@ Application::Application(int& argc, char** argv):
     argv_ = argv;
 
     setApplicationVersion(QStringLiteral(PCMANFM_QT_VERSION));
+    setDesktopFileName(QStringLiteral("pcmanfm-qt"));
     setWindowIcon(QIcon::fromTheme(QStringLiteral("pcmanfm-qt")));
 
     underWayland_ = QGuiApplication::platformName() == QStringLiteral("wayland");


### PR DESCRIPTION
fixes the appid and class across wayland compositors when QT_QPA_PLATFORM=wayland is set

the current behaviour only works when it's QT_QPA_PLATFORM=xcb