### PR TITLE
set preference class to pcmanfm-qt-preferences

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -677,7 +677,9 @@ void Application::preferences(const QString& page) {
     else {
         preferencesDialog_.data()->selectPage(page);
     }
-    preferencesDialog_.data()->show();
+    QGuiApplication::setDesktopFileName(QStringLiteral("pcmanfm-qt-preferences"));
+	preferencesDialog_.data()->show();
+	QGuiApplication::setDesktopFileName(QStringLiteral("pcmanfm-qt"));
     preferencesDialog_.data()->raise();
     preferencesDialog_.data()->activateWindow();
 }


### PR DESCRIPTION
this allows setting up window rules for the preferences dialog with no real downsides?

any reason not to do this would be appreciated, it really helps with tiling WM's especially and doesn't hurt anything that I can distinguish, very small change