### PR TITLE
Desktop prefs: Merge Background and Slide Show tabs

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -316,7 +316,7 @@ are left clicked, even when it is not the default file manager.</string>
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_2">
+        <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -451,7 +451,125 @@ are left clicked, even when it is not the default file manager.</string>
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_4">
+         <widget class="QGroupBox" name="slideShow">
+           <property name="title">
+             <string>Enable Slide Show</string>
+           </property>
+           <property name="checkable">
+             <bool>true</bool>
+           </property>
+           <property name="checked">
+             <bool>false</bool>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_4">
+             <item row="0" column="0" colspan="7">
+               <widget class="QLabel" name="label_10">
+                 <property name="text">
+                   <string>Wallpaper image folder:</string>
+                 </property>
+               </widget>
+             </item>
+             <item row="1" column="0" colspan="6">
+               <widget class="QLineEdit" name="imageFolder">
+                 <property name="placeholderText">
+                   <string>Wallpaper folder</string>
+                 </property>
+               </widget>
+             </item>
+             <item row="1" column="6">
+               <widget class="QPushButton" name="folderBrowse">
+                 <property name="text">
+                   <string>Browse</string>
+                 </property>
+               </widget>
+             </item>
+             <item row="2" column="2">
+               <widget class="QSpinBox" name="hours">
+                 <property name="suffix">
+                   <string> hour(s)</string>
+                 </property>
+                 <property name="maximum">
+                   <number>24</number>
+                 </property>
+               </widget>
+             </item>
+             <item row="2" column="3">
+               <widget class="QLabel" name="label_12">
+                 <property name="text">
+                   <string>and</string>
+                 </property>
+                 <property name="alignment">
+                   <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="margin">
+                   <number>5</number>
+                 </property>
+               </widget>
+             </item>
+             <item row="2" column="0">
+               <widget class="QLabel" name="label_11">
+                 <property name="toolTip">
+                   <string>Intervals less than 5min will be ignored</string>
+                 </property>
+                 <property name="text">
+                   <string>Interval:</string>
+                 </property>
+               </widget>
+             </item>
+             <item row="2" column="4">
+               <widget class="QSpinBox" name="minutes">
+                 <property name="suffix">
+                   <string> minute(s)</string>
+                 </property>
+                 <property name="maximum">
+                   <number>55</number>
+                 </property>
+                 <property name="singleStep">
+                   <number>5</number>
+                 </property>
+               </widget>
+             </item>
+             <item row="2" column="5">
+               <spacer name="horizontalSpacer_2">
+                 <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                   <size>
+                     <width>10</width>
+                     <height>5</height>
+                   </size>
+                 </property>
+               </spacer>
+             </item>
+             <item row="2" column="1">
+               <spacer name="horizontalSpacer_3">
+                 <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeType">
+                   <enum>QSizePolicy::Minimum</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                   <size>
+                     <width>5</width>
+                     <height>5</height>
+                   </size>
+                 </property>
+               </spacer>
+             </item>
+             <item row="3" column="0" colspan="6">
+               <widget class="QCheckBox" name="randomize">
+                 <property name="text">
+                   <string>Randomize the slide show</string>
+                 </property>
+               </widget>
+             </item>
+           </layout>
+         </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_1">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -462,147 +580,6 @@ are left clicked, even when it is not the default file manager.</string>
           <size>
            <width>20</width>
            <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="slidePage">
-      <attribute name="title">
-       <string>Slide Show</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <widget class="QGroupBox" name="slideShow">
-         <property name="title">
-          <string>Enable Slide Show</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_4">
-          <item row="0" column="0" colspan="7">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Wallpaper image folder:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="6">
-           <widget class="QLineEdit" name="imageFolder">
-            <property name="placeholderText">
-             <string>Wallpaper folder</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="6">
-           <widget class="QPushButton" name="folderBrowse">
-            <property name="text">
-             <string>Browse</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QSpinBox" name="hours">
-            <property name="suffix">
-             <string> hour(s)</string>
-            </property>
-            <property name="maximum">
-             <number>24</number>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QLabel" name="label_12">
-            <property name="text">
-             <string>and</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-            <property name="margin">
-             <number>5</number>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_11">
-            <property name="toolTip">
-             <string>Intervals less than 5min will be ignored</string>
-            </property>
-            <property name="text">
-             <string>Interval:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="4">
-           <widget class="QSpinBox" name="minutes">
-            <property name="suffix">
-             <string> minute(s)</string>
-            </property>
-            <property name="maximum">
-             <number>55</number>
-            </property>
-            <property name="singleStep">
-             <number>5</number>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="5">
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>10</width>
-              <height>5</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="2" column="1">
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Minimum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>5</width>
-              <height>5</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="3" column="0" colspan="6">
-           <widget class="QCheckBox" name="randomize">
-            <property name="text">
-             <string>Randomize the slide show</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::MinimumExpanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
           </size>
          </property>
         </spacer>
@@ -671,7 +648,7 @@ are left clicked, even when it is not the default file manager.</string>
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer">
+        <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>

--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -447,25 +447,38 @@ are left clicked, even when it is not the default file manager.</string>
             </property>
            </widget>
           </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-         <widget class="QGroupBox" name="slideShow">
-           <property name="title">
-             <string>Enable Slide Show</string>
-           </property>
-           <property name="checkable">
-             <bool>true</bool>
-           </property>
-           <property name="checked">
-             <bool>false</bool>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_4">
+          <item row="5" column="0" colspan="2">
+           <spacer name="verticalSpacer_1">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::MinimumExpanding</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>10</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="6" column="0" colspan="2">
+           <widget class="QGroupBox" name="slideShow">
+            <property name="title">
+              <string>Enable Slide Show</string>
+            </property>
+            <property name="checkable">
+              <bool>true</bool>
+            </property>
+            <property name="checked">
+              <bool>false</bool>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_4">
              <item row="0" column="0" colspan="7">
                <widget class="QLabel" name="label_10">
                  <property name="text">
-                   <string>Wallpaper image folder:</string>
+                   <string>Wallpaper folder:</string>
                  </property>
                </widget>
              </item>
@@ -543,33 +556,36 @@ are left clicked, even when it is not the default file manager.</string>
                </spacer>
              </item>
              <item row="2" column="1">
-               <spacer name="horizontalSpacer_3">
-                 <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeType">
-                   <enum>QSizePolicy::Minimum</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                   <size>
-                     <width>5</width>
-                     <height>5</height>
-                   </size>
-                 </property>
-               </spacer>
-             </item>
-             <item row="3" column="0" colspan="6">
-               <widget class="QCheckBox" name="randomize">
-                 <property name="text">
-                   <string>Randomize the slide show</string>
-                 </property>
-               </widget>
-             </item>
-           </layout>
+              <spacer name="horizontalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Minimum</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+               <size>
+                <width>5</width>
+                <height>5</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="3" column="0" colspan="6">
+              <widget class="QCheckBox" name="randomize">
+               <property name="text">
+              <string>Randomize the slide show</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
+         </item>
+         </layout>
+        </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_1">
+        <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -648,7 +664,7 @@ are left clicked, even when it is not the default file manager.</string>
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_2">
+        <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>


### PR DESCRIPTION
Background/wallpaper and wallpaper slideshows are in the same category, so on that basis they could be grouped. Thankfully after merging there was less space used than for the General tab. This basically simplifies the GUI.